### PR TITLE
Fix: Use filename session ID for resume functionality

### DIFF
--- a/src/utils/conversationReader.ts
+++ b/src/utils/conversationReader.ts
@@ -62,6 +62,10 @@ async function readConversation(filePath: string, projectDir: string): Promise<C
       return null;
     }
     
+    // Extract session ID from filename
+    const filename = filePath.split('/').pop() || '';
+    const filenameSessionId = filename.replace('.jsonl', '');
+    
     const messages: Message[] = [];
     for (const line of lines) {
       try {
@@ -104,18 +108,13 @@ async function readConversation(filePath: string, projectDir: string): Promise<C
       return null;
     }
     
-    // Find a valid session ID from messages (use the last one found)
-    let sessionId = '';
-    for (let i = messages.length - 1; i >= 0; i--) {
-      const msg = messages[i];
-      if (msg.sessionId && msg.sessionId !== 'undefined') {
-        sessionId = msg.sessionId;
-        break;
-      }
-    }
+    // Use session ID from filename as it's what Claude expects for --resume
+    // The filename is the original session ID that Claude uses for resuming
+    const sessionId = filenameSessionId;
     
-    // Skip if no valid session ID found
-    if (!sessionId) {
+    // Validate that it looks like a valid UUID
+    const uuidRegex = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+    if (!sessionId || !uuidRegex.test(sessionId)) {
       return null;
     }
     


### PR DESCRIPTION
## Summary
- Fixed resume functionality by using the session ID from the filename instead of searching within file contents
- Added UUID validation to ensure extracted session IDs are valid

## Problem
The resume feature was failing because it was using the last session ID found within conversation files. However, conversation files can contain multiple session IDs when conversations are resumed or branched. Claude's `--resume` command expects the original session ID, which is the filename of the `.jsonl` file.

## Solution
- Extract session ID directly from the filename (e.g., `71d0b5a6-b3b5-428d-a94b-3cb8bb1b8a42.jsonl` → `71d0b5a6-b3b5-428d-a94b-3cb8bb1b8a42`)
- Validate that the extracted ID matches UUID format
- Remove the previous logic that searched through message entries

## Test plan
- [x] Build passes (`npm run build`)
- [x] All tests pass (`npm test`)
- [ ] Manually test resume functionality with conversations that have multiple session IDs
- [ ] Verify that conversations with invalid filenames are properly skipped

🤖 Generated with [Claude Code](https://claude.ai/code)