### PR TITLE
feat: Add conversation selection keys to dynamic help text

### DIFF
--- a/src/utils/shortcutHelper.ts
+++ b/src/utils/shortcutHelper.ts
@@ -26,6 +26,7 @@ export function getShortcutText(config: Config): string {
   };
   
   // Build shortcuts in logical groups
+  shortcuts.push(`Select: ${formatKeys(config.keybindings.selectPrevious)}/${formatKeys(config.keybindings.selectNext)}`);
   shortcuts.push(`Scroll: ${formatKeys(config.keybindings.scrollUp)}/${formatKeys(config.keybindings.scrollDown)}`);
   shortcuts.push(`Page: ${formatKeys(config.keybindings.scrollPageDown)}/${formatKeys(config.keybindings.scrollPageUp)}`);
   shortcuts.push(`Top: ${formatKeys(config.keybindings.scrollTop)}`);


### PR DESCRIPTION
## Summary
- Added conversation selection keys (up/down arrows) to the dynamically generated help text
- Updated `shortcutHelper.ts` to include `selectPrevious`/`selectNext` keybindings in the help display

## Context
This is a follow-up to PR #4 which added custom keybinding support. The dynamic help text was missing the selection keys, making it incomplete. This PR ensures all available keyboard shortcuts are displayed to users.

## Changes
- Modified `src/utils/shortcutHelper.ts` to add selection keys at the beginning of the shortcut list
- Selection keys now properly reflect custom keybindings if configured

## Test Results
- ✅ All tests passing
- ✅ Linting successful
- ✅ Type checking successful

## Screenshots
Before: Help text missing selection keys
After: `Select: ↑/↓` now appears at the beginning of the help text

🤖 Generated with [Claude Code](https://claude.ai/code)