### PR TITLE
chore: configure Dependabot to ignore React 19 updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,7 +7,7 @@ updates:
       interval: "weekly"
       day: "monday"
       time: "04:00"
-    open-pull-requests-limit: 10
+    open-pull-requests-limit: 5
     reviewers:
       - "sasazame"
     labels:
@@ -16,6 +16,22 @@ updates:
     commit-message:
       prefix: "chore"
       include: "scope"
+    groups:
+      eslint:
+        patterns:
+          - "eslint*"
+          - "@typescript-eslint/*"
+          - "typescript-eslint"
+      react:
+        patterns:
+          - "react*"
+          - "@types/react*"
+      testing:
+        patterns:
+          - "jest*"
+          - "@types/jest"
+          - "ts-jest"
+          - "*testing*"
     
   # Keep GitHub Actions up to date
   - package-ecosystem: "github-actions"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -32,6 +32,12 @@ updates:
           - "@types/jest"
           - "ts-jest"
           - "*testing*"
+    ignore:
+      # Ink doesn't support React 19 yet
+      - dependency-name: "react"
+        versions: [">=19.0.0"]
+      - dependency-name: "@types/react"
+        versions: [">=19.0.0"]
     
   # Keep GitHub Actions up to date
   - package-ecosystem: "github-actions"


### PR DESCRIPTION
## Summary
- Added ignore rules for React 19+ in Dependabot configuration
- This prevents Dependabot from creating PRs for React 19 updates until Ink supports it

## Context
PR #9 failed because Ink (our TUI library) doesn't support React 19 yet. The error was:
```
TypeError: Cannot read properties of undefined (reading 'ReactCurrentOwner')
```

This is due to react-reconciler compatibility issues with React 19.

## Changes
- Configure Dependabot to ignore react >=19.0.0
- Configure Dependabot to ignore @types/react >=19.0.0
- Also optimized dependency grouping configuration from previous commit

Once Ink releases React 19 support, we can remove these ignore rules.

🤖 Generated with [Claude Code](https://claude.ai/code)