### PR TITLE
feat: implement pagination and performance optimizations

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,6 +92,8 @@ ccresume . --model opus
 | Page Down | `d`, `PageDown` |
 | Scroll to Top | `g` |
 | Scroll to Bottom | `G` |
+| Next Page | `→`, `n` |
+| Previous Page | `←`, `p` |
 
 ### Custom Key Bindings
 
@@ -110,6 +112,8 @@ scrollPageUp = ["b", "ctrl+b"]
 scrollPageDown = ["f", "ctrl+f"]
 scrollTop = ["g"]
 scrollBottom = ["shift+g"]
+pageNext = ["right", "n"]
+pagePrevious = ["left", "p"]
 ```
 
 See `config.toml.example` in the repository for a complete example.
@@ -178,12 +182,10 @@ Contributions are welcome! Please feel free to submit a Pull Request.
 
 ## Performance Considerations
 
-- ccresume currently loads all conversations on startup
-- With a large number of conversations (1000+), initial loading may take a few seconds
-- Future improvements may include:
-  - Pagination or lazy loading for better performance with large datasets
-  - Configurable limits on the number of conversations displayed
-  - Caching mechanisms for faster repeated access
+- ccresume uses lazy loading and pagination to handle large numbers of conversations efficiently
+- Only 30 conversations are loaded at a time, providing fast startup even with thousands of conversations
+- Navigate between pages using the arrow keys (← →) or custom keybindings
+- The tool automatically detects the total number of conversations without loading them all
 
 ## License
 

--- a/config.toml.example
+++ b/config.toml.example
@@ -22,3 +22,7 @@ scrollPageUp = ["u", "pageup"]
 scrollPageDown = ["d", "pagedown"]
 scrollTop = ["g"]
 scrollBottom = ["G"]
+
+# Pagination controls
+pageNext = ["right", "n"]
+pagePrevious = ["left", "p"]

--- a/docs/claude_project_mapping.md
+++ b/docs/claude_project_mapping.md
@@ -1,0 +1,106 @@
+# Claude Project Directory Mapping
+
+## Overview
+
+Claude stores conversation files in `~/.claude/projects/` using a specific directory naming pattern that maps to actual project paths.
+
+## Directory Naming Pattern
+
+Claude creates directory names by replacing certain characters in the absolute path with hyphens (`-`).
+
+### Transformation Rules:
+
+1. **Forward Slash**: `/` → `-`
+   - Example: `/home/user/git/cc-resume` → `-home-user-git-cc-resume`
+
+2. **Dot**: `.` → `-`
+   - Example: `/home/user/.dotfiles` → `-home-user--dotfiles`
+   - Note: This creates double hyphens when a dot follows a slash
+
+3. **Edge Cases**:
+   - Paths containing hyphens are preserved, which can lead to consecutive hyphens
+   - Example: `/home/user/my-project` → `-home-user-my-project`
+
+## Implementation
+
+### Path to Directory Name
+
+```bash
+# Convert a path to Claude's directory name format
+path_to_claude_dir() {
+    echo "$1" | sed 's/[/.]/-/g'
+}
+
+# Example usage:
+path_to_claude_dir "/home/user/git/cc-resume"
+# Output: -home-user-git-cc-resume
+
+path_to_claude_dir "/home/user/.dotfiles"
+# Output: -home-user--dotfiles
+```
+
+In JavaScript/TypeScript:
+```typescript
+function pathToClaudeDir(path: string): string {
+  return path.replace(/[/.]/g, '-');
+}
+```
+
+### Directory Name to Path (Reverse)
+
+```bash
+# Convert Claude's directory name back to path
+# WARNING: This transformation is NOT reversible!
+# Multiple different paths can map to the same directory name
+# For example: 
+#   /home/user/.config → -home-user--config
+#   /home/user/-config → -home-user--config
+# Both produce the same directory name, making reverse mapping ambiguous
+```
+
+## Filtering Conversations by Current Directory
+
+To filter conversations for the current directory without reading conversation files:
+
+```bash
+# Get the Claude project directory name for the current path
+current_dir=$(pwd)
+claude_dir=$(echo "$current_dir" | sed 's/[/.]/-/g')
+project_path="$HOME/.claude/projects/$claude_dir"
+
+# Check if conversations exist for current directory
+if [ -d "$project_path" ]; then
+    echo "Found conversations in: $project_path"
+    ls -la "$project_path"/*.jsonl 2>/dev/null
+else
+    echo "No conversations found for current directory"
+fi
+```
+
+## Examples
+
+| Actual Path | Claude Directory Name |
+|------------|---------------------|
+| `/home/user` | `-home-user` |
+| `/home/user/git` | `-home-user-git` |
+| `/home/user/git/cc-resume` | `-home-user-git-cc-resume` |
+| `/home/user/.dotfiles` | `-home-user--dotfiles` |
+| `/home/user/playground-20250610` | `-home-user-playground-20250610` |
+
+## Performance Implications
+
+Understanding this mapping is crucial for performance optimization in tools like ccresume:
+
+1. **Without directory filtering**: Must read all conversation files to check their `projectPath`
+2. **With directory filtering**: Can skip entire directories at the file system level
+
+For example, if you have 1000 conversations across 50 projects but only 30 in the current directory:
+- Without optimization: Reads 1000 files
+- With optimization: Reads only 30 files from the matching directory
+
+## Notes
+
+- The transformation is **not reversible** due to both `/` and `.` mapping to `-`
+- All conversation files for a project are stored as `.jsonl` files within the project directory
+- Each `.jsonl` file is named with a UUID (e.g., `6b983a59-1103-4657-89fd-b32c30ebe875.jsonl`)
+- There is no separate metadata file mapping directory names to paths - the mapping is done through the naming convention itself

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -2,7 +2,7 @@ import React, { useState, useEffect } from 'react';
 import { Box, Text, useInput, useApp, useStdout } from 'ink';
 import { ConversationList } from './components/ConversationList.js';
 import { ConversationPreview } from './components/ConversationPreview.js';
-import { getAllConversations } from './utils/conversationReader.js';
+import { getPaginatedConversations } from './utils/conversationReader.js';
 import { spawn } from 'child_process';
 import clipboardy from 'clipboardy';
 import type { Conversation } from './types.js';
@@ -25,6 +25,12 @@ const App: React.FC<AppProps> = ({ claudeArgs = [], currentDirOnly = false }) =>
   const [dimensions, setDimensions] = useState({ width: 80, height: 24 });
   const [statusMessage, setStatusMessage] = useState<string | null>(null);
   const [config, setConfig] = useState<Config | null>(null);
+  
+  // Pagination state
+  const [currentPage, setCurrentPage] = useState(0);
+  const [totalCount, setTotalCount] = useState(0);
+  const [paginating, setPaginating] = useState(false);
+  const ITEMS_PER_PAGE = 30;
 
   useEffect(() => {
     // Load config on mount
@@ -55,18 +61,45 @@ const App: React.FC<AppProps> = ({ claudeArgs = [], currentDirOnly = false }) =>
     return undefined;
   }, [stdout]);
 
-  const loadConversations = async () => {
+  const loadConversations = async (isPaginating = false) => {
     try {
-      setLoading(true);
+      if (isPaginating) {
+        setPaginating(true);
+        setConversations([]); // Clear current conversations
+      } else {
+        setLoading(true);
+      }
+      
       const currentDir = currentDirOnly ? process.cwd() : undefined;
-      const convs = await getAllConversations(currentDir);
+      
+      // Load paginated conversations
+      const offset = currentPage * ITEMS_PER_PAGE;
+      const { conversations: convs, total } = await getPaginatedConversations({
+        limit: ITEMS_PER_PAGE,
+        offset,
+        currentDirFilter: currentDir
+      });
       setConversations(convs);
+      setTotalCount(total);
+      
       setLoading(false);
+      setPaginating(false);
     } catch (err) {
       setError(err instanceof Error ? err.message : 'Failed to load conversations');
       setLoading(false);
+      setPaginating(false);
     }
   };
+
+  // Track previous page for detecting page changes
+  const [prevPage, setPrevPage] = useState(0);
+  
+  // Reload conversations when page changes
+  useEffect(() => {
+    const isPaginating = currentPage !== prevPage;
+    setPrevPage(currentPage);
+    loadConversations(isPaginating);
+  }, [currentPage, currentDirOnly]); // eslint-disable-line react-hooks/exhaustive-deps
 
   useInput((input, key) => {
     if (!config) return;
@@ -77,12 +110,43 @@ const App: React.FC<AppProps> = ({ claudeArgs = [], currentDirOnly = false }) =>
 
     if (loading || conversations.length === 0) return;
 
+    // Calculate pagination values
+    const totalPages = Math.ceil(totalCount / ITEMS_PER_PAGE);
+    
     if (matchesKeyBinding(input, key, config.keybindings.selectPrevious)) {
-      setSelectedIndex((prev) => Math.max(0, prev - 1));
+      if (selectedIndex === 0 && currentPage > 0) {
+        // Auto-navigate to previous page when at first item
+        setCurrentPage(prev => prev - 1);
+        setSelectedIndex(ITEMS_PER_PAGE - 1); // Select last item of previous page
+      } else {
+        setSelectedIndex((prev) => Math.max(0, prev - 1));
+      }
     }
     
     if (matchesKeyBinding(input, key, config.keybindings.selectNext)) {
-      setSelectedIndex((prev) => Math.min(conversations.length - 1, prev + 1));
+      const maxIndex = conversations.length - 1;
+      const canGoNext = totalCount === -1 ? conversations.length === ITEMS_PER_PAGE : currentPage < totalPages - 1;
+      if (selectedIndex === maxIndex && canGoNext) {
+        // Auto-navigate to next page when at last item
+        setCurrentPage(prev => prev + 1);
+        setSelectedIndex(0); // Select first item of next page
+      } else {
+        setSelectedIndex((prev) => Math.min(maxIndex, prev + 1));
+      }
+    }
+    
+    // Page navigation with arrow keys and n/p
+    if (matchesKeyBinding(input, key, config.keybindings.pageNext)) {
+      // For unknown total (-1), allow next if we got full page
+      if (totalCount === -1 ? conversations.length === ITEMS_PER_PAGE : currentPage < totalPages - 1) {
+        setCurrentPage(prev => prev + 1);
+        setSelectedIndex(0); // Reset selection to first item of new page
+      }
+    }
+    
+    if (matchesKeyBinding(input, key, config.keybindings.pagePrevious) && currentPage > 0) {
+      setCurrentPage(prev => prev - 1);
+      setSelectedIndex(0); // Reset selection to first item of new page
     }
     
 
@@ -174,12 +238,15 @@ const App: React.FC<AppProps> = ({ claudeArgs = [], currentDirOnly = false }) =>
     );
   }
 
+  // Get the selected conversation
   const selectedConversation = conversations[selectedIndex] || null;
   
+  const totalPages = Math.ceil(totalCount / ITEMS_PER_PAGE);
+  
   // Calculate heights for fixed layout
-  const headerHeight = 1; // Title only
+  const headerHeight = 2; // Title + pagination info
   const listMaxHeight = 9; // Maximum height for conversation list
-  const visibleConversations = Math.min(4, conversations.length); // Show max 4 conversations
+  const visibleConversations = Math.min(4, conversations.length); // Show max 4 conversations per page
   // List height calculation: 
   // 2 (borders) + 1 (title) + visibleConversations + 1 (more message if needed)
   const needsMoreIndicator = conversations.length > visibleConversations ? 1 : 0;
@@ -190,8 +257,23 @@ const App: React.FC<AppProps> = ({ claudeArgs = [], currentDirOnly = false }) =>
 
   return (
     <Box flexDirection="column" width={dimensions.width} height={dimensions.height} paddingX={1} paddingY={0}>
-      <Box height={headerHeight}>
+      <Box height={headerHeight} flexDirection="column">
         <Text bold color="cyan">ccresume - Claude Code Conversation Browser</Text>
+        <Box>
+          <Text dimColor>
+            {(() => {
+              const prevKeys = config?.keybindings.pagePrevious.map(k => k === 'left' ? '←' : k).join('/') || '←';
+              const nextKeys = config?.keybindings.pageNext.map(k => k === 'right' ? '→' : k).join('/') || '→';
+              const pageHelp = `Press ${prevKeys}/${nextKeys} for pages`;
+              
+              return totalCount === -1 ? (
+                <>Page {currentPage + 1} | {pageHelp}</>
+              ) : (
+                <>{totalCount} total | Page {currentPage + 1}/{totalPages || 1} | {pageHelp}</>
+              );
+            })()}
+          </Text>
+        </Box>
       </Box>
       
       <Box height={listHeight}>
@@ -199,6 +281,7 @@ const App: React.FC<AppProps> = ({ claudeArgs = [], currentDirOnly = false }) =>
           conversations={conversations} 
           selectedIndex={selectedIndex}
           maxVisible={visibleConversations}
+          isLoading={paginating}
         />
       </Box>
       

--- a/src/__tests__/ConversationList.test.tsx
+++ b/src/__tests__/ConversationList.test.tsx
@@ -42,7 +42,7 @@ describe('ConversationList', () => {
       />
     );
     
-    expect(lastFrame()).toContain('Select a conversation (1 total)');
+    expect(lastFrame()).toContain('Select a conversation (1 shown):');
     // Session ID is no longer displayed in the list
     expect(lastFrame()).not.toContain('[12345678]');
     expect(lastFrame()).toContain('/home/user/project'); // Full project path (shortening only works for actual home directory)
@@ -81,6 +81,6 @@ describe('ConversationList', () => {
       />
     );
     
-    expect(lastFrame()).toContain('↓ 7 more...');
+    expect(lastFrame()).toContain('↓ 7 more on this page...');
   });
 });

--- a/src/__tests__/ConversationPreview.test.tsx
+++ b/src/__tests__/ConversationPreview.test.tsx
@@ -50,7 +50,8 @@ describe('ConversationPreview', () => {
       <ConversationPreview conversation={null} />
     );
     
-    expect(lastFrame()).toContain('Select a conversation to preview');
+    // Should render an empty box without text
+    expect(lastFrame()).not.toContain('Select a conversation to preview');
   });
 
   it('renders conversation header correctly', () => {
@@ -343,8 +344,8 @@ describe('ConversationPreview', () => {
       stdin.write('g');
       stdin.write('G');
       
-      // Should still show empty state
-      expect(lastFrame()).toContain('Select a conversation to preview');
+      // Should still show empty state (no text)
+      expect(lastFrame()).not.toContain('Select a conversation to preview');
     });
   });
 

--- a/src/cli.tsx
+++ b/src/cli.tsx
@@ -31,6 +31,7 @@ All other options are passed to claude when resuming a conversation.
 
 Keyboard Controls:
   ↑/↓           Navigate conversations list
+  ←/→           Navigate between pages
   j/k           Scroll chat history  
   Enter         Resume selected conversation
   c             Copy session ID

--- a/src/components/ConversationList.tsx
+++ b/src/components/ConversationList.tsx
@@ -10,12 +10,14 @@ interface ConversationListProps {
   conversations: Conversation[];
   selectedIndex: number;
   maxVisible?: number;
+  isLoading?: boolean;
 }
 
 export const ConversationList: React.FC<ConversationListProps> = ({ 
   conversations, 
   selectedIndex,
-  maxVisible = 3
+  maxVisible = 3,
+  isLoading = false
 }) => {
   const { stdout } = useStdout();
   const terminalWidth = stdout?.columns || 80;
@@ -43,9 +45,12 @@ export const ConversationList: React.FC<ConversationListProps> = ({
 
   return (
     <Box flexDirection="column" borderStyle="single" borderColor="cyan" paddingX={1} width="100%" overflow="hidden">
-      <Text bold color="cyan">Select a conversation ({conversations.length} total):</Text>
+      <Text bold color="cyan">{isLoading ? 'Loading conversations...' : `Select a conversation${conversations.length > 0 ? ` (${conversations.length} shown)` : ''}:`}</Text>
       
-      {conversations.length === 0 ? (
+      {isLoading ? (
+        <Box flexDirection="column" height={maxVisible}>
+        </Box>
+      ) : conversations.length === 0 ? (
         <Text color="gray">No conversations found</Text>
       ) : (
         visibleConversations.map((conv, visibleIndex) => {
@@ -93,7 +98,7 @@ export const ConversationList: React.FC<ConversationListProps> = ({
       
       {hasMoreBelow && (
         <Box width="100%">
-          <Text color="cyan">↓ {conversations.length - endIndex} more...</Text>
+          <Text color="cyan">↓ {conversations.length - endIndex} more on this page...</Text>
         </Box>
       )}
     </Box>

--- a/src/components/ConversationPreview.tsx
+++ b/src/components/ConversationPreview.tsx
@@ -103,7 +103,6 @@ export const ConversationPreview: React.FC<ConversationPreviewProps> = ({ conver
   if (!conversation) {
     return (
       <Box borderStyle="single" borderColor="gray" paddingX={1} flexGrow={1}>
-        <Text color="gray">Select a conversation to preview</Text>
       </Box>
     );
   }

--- a/src/types/config.ts
+++ b/src/types/config.ts
@@ -10,6 +10,8 @@ export interface KeyBindings {
   scrollPageDown: string[];
   scrollTop: string[];
   scrollBottom: string[];
+  pageNext: string[];
+  pagePrevious: string[];
 }
 
 export interface Config {
@@ -29,5 +31,7 @@ export const defaultConfig: Config = {
     scrollPageDown: ['d', 'pagedown'],
     scrollTop: ['g'],
     scrollBottom: ['G'],
+    pageNext: ['right'],
+    pagePrevious: ['left'],
   },
 };


### PR DESCRIPTION
## Summary
- Implement lazy loading pagination (30 items per page) for better performance with large conversation counts
- Optimize directory filtering to read only relevant files instead of all conversations
- Improve UI/UX with better loading states and customizable keybindings

## Key Changes

### Performance Optimizations
- **Pagination**: Always load only 30 conversations at a time (removed --search-all option)
- **Directory Filtering Fix**: When using `ccresume .`, now correctly filters at the directory level using Claude's naming pattern
  - Before: Read ALL conversation files to check their projectPath
  - After: Only read files from the matching directory
- **Path Mapping**: Discovered and documented that Claude converts both `/` and `.` to `-` in directory names

### UI/UX Improvements
- Removed "Select a conversation to preview" text for cleaner interface
- Added loading state that maintains consistent frame size during pagination
- Made pagination keys customizable (default: ← → arrow keys)
- Dynamic help text shows actual configured keybindings

### Documentation
- Added comprehensive Claude project directory mapping documentation
- Updated README to reflect new pagination behavior
- Updated all keyboard shortcut documentation

## Test Plan
- [x] All tests pass (`npm test`)
- [x] TypeScript compilation successful (`npm run typecheck`)
- [x] No linting errors (`npm run lint`)
- [x] Manual testing of pagination with arrow keys
- [x] Verified directory filtering performance improvement with `ccresume .`
- [x] Confirmed loading states display correctly


🤖 Generated with [Claude Code](https://claude.ai/code)