### PR TITLE
feat: add --hide option to filter message types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- New `--hide` option to hide specific message types (#27)
+  - Hide tool use messages with `--hide tool`
+  - Hide thinking messages with `--hide thinking`
+  - Hide user messages with `--hide user`
+  - Hide assistant messages with `--hide assistant`
+  - Default behavior (no arguments): `--hide` hides both tool and thinking messages
+  - Multiple message types can be hidden: `--hide tool thinking user`
+- Improved command-line argument parsing with validation for hide options
+
 ## [0.2.0] - 2025-07-07
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ ccresume provides an interactive terminal interface to browse and manage your Cl
 - 🔍 View detailed conversation information
 - 📎 Copy session IDs to clipboard
 - 📁 Filter conversations to current directory with `.` argument
+- 🎭 Hide specific message types for cleaner display
 
 ![ccresume demo](docs/images/demo.gif)
 
@@ -47,10 +48,34 @@ Or if using npx:
 npx @sasazame/ccresume@latest
 ```
 
-### Passing Options to Claude
+### Command Line Options
 
-**Important**: All command-line arguments are passed directly to the `claude` command when resuming a conversation.
+#### ccresume Options
 
+```bash
+# Hide specific message types
+ccresume --hide              # Default: hides tool and thinking messages
+ccresume --hide tool         # Hide only tool messages
+ccresume --hide thinking      # Hide only thinking messages
+ccresume --hide user         # Hide only user messages
+ccresume --hide assistant    # Hide only assistant messages
+ccresume --hide tool thinking user  # Hide multiple types
+
+# Filter to current directory
+ccresume .
+
+# Show help
+ccresume --help
+ccresume -h
+
+# Show version
+ccresume --version
+ccresume -v
+```
+
+#### Passing Options to Claude
+
+All unrecognized command-line arguments are passed directly to the `claude` command when resuming a conversation.
 
 ```bash
 # Pass options to claude
@@ -59,14 +84,12 @@ ccresume --dangerously-skip-permissions
 # Multiple options
 ccresume --model opus --dangerously-skip-permissions
 
-# Filter to current directory only
-ccresume .
-
-# Combine with claude options
-ccresume . --model opus 
+# Combine ccresume and claude options
+ccresume --hide tool --model opus 
+ccresume . --hide --dangerously-skip-permissions
 ```
 
-**⚠️ Warning**: Since all arguments are passed to claude, avoid using options that conflict with ccresume's functionality:
+**⚠️ Warning**: Since unrecognized arguments are passed to claude, avoid using options that conflict with ccresume's functionality:
 - Don't use options like `--resume` or something like that changes claude's interactive behavior
 
 ## Requirements

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -13,9 +13,10 @@ import type { Config } from './types/config.js';
 interface AppProps {
   claudeArgs?: string[];
   currentDirOnly?: boolean;
+  hideOptions?: string[];
 }
 
-const App: React.FC<AppProps> = ({ claudeArgs = [], currentDirOnly = false }) => {
+const App: React.FC<AppProps> = ({ claudeArgs = [], currentDirOnly = false, hideOptions = [] }) => {
   const { exit } = useApp();
   const { stdout } = useStdout();
   const [conversations, setConversations] = useState<Conversation[]>([]);
@@ -286,7 +287,7 @@ const App: React.FC<AppProps> = ({ claudeArgs = [], currentDirOnly = false }) =>
       </Box>
       
       <Box height={previewHeight}>
-        <ConversationPreview conversation={selectedConversation} statusMessage={statusMessage} />
+        <ConversationPreview conversation={selectedConversation} statusMessage={statusMessage} hideOptions={hideOptions} />
       </Box>
       
       {/* Bottom margin to absorb any overflow */}


### PR DESCRIPTION
## Summary
- Implements `--hide` CLI option to hide specific message types in conversation preview
- Addresses user request in #27 for cleaner display in small terminal panes
- Supports hiding tool, thinking, user, and assistant messages

## Changes
- Added `--hide [types...]` CLI option with validation
- Modified conversation preview to filter messages based on hide options
- Default behavior: `--hide` (no args) hides tool and thinking messages
- Updated documentation (README.md and CHANGELOG.md)

## Usage Examples
```bash
# Hide tool and thinking messages (default)
ccresume --hide

# Hide specific message types
ccresume --hide tool
ccresume --hide thinking
ccresume --hide user assistant

# Combine with other options
ccresume . --hide tool --dangerously-skip-permissions
```

## Test Plan
- [x] Tested CLI argument parsing with various combinations
- [x] Verified message filtering works correctly
- [x] Tested edge cases (invalid options, dot argument, etc.)
- [x] Confirmed other CLI options still work correctly
- [x] Built and type-checked successfully

## Screenshot

### Before

<img width="1095" height="568" alt="image" src="https://github.com/user-attachments/assets/5026a619-5841-401a-b2a5-56b3a3273383" />


### After

- using `--hide`

<img width="1095" height="568" alt="image" src="https://github.com/user-attachments/assets/db380d42-3148-41e2-a44c-cc32ba3e71d9" />

- using `--hide assistant tool thinking`

<img width="1097" height="551" alt="image" src="https://github.com/user-attachments/assets/867b6c07-32d3-4fb5-a5de-d5878f0a8f00" />


Closes #27

🤖 Generated with [Claude Code](https://claude.ai/code)