### PR TITLE
chore: merge back v0.3.0 release changes

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@sasazame/ccresume",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@sasazame/ccresume",
-      "version": "0.2.0",
+      "version": "0.3.0",
       "license": "MIT",
       "dependencies": {
         "@iarna/toml": "^2.2.5",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sasazame/ccresume",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "description": "A TUI tool for browsing and resuming Claude Code conversations",
   "type": "module",
   "bin": {


### PR DESCRIPTION
Merge back release changes from v0.3.0

This PR merges the version bump from the v0.3.0 release back into the develop branch to keep both branches in sync.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the application version to 0.3.0.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->