### PR TITLE
fix: Preserve terminal scrollback buffer when exiting

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -253,6 +253,10 @@ const App: React.FC<AppProps> = ({ claudeArgs = [], currentDirOnly = false, hide
   
   const totalPages = Math.ceil(totalCount / ITEMS_PER_PAGE);
   
+  // Constants for layout calculation
+  const SAFETY_MARGIN = 1; // Prevents Ink from clearing terminal when output approaches height limit
+  const MIN_PREVIEW_HEIGHT = 10;
+  
   // Calculate heights for fixed layout
   const headerHeight = 2; // Title + pagination info
   const listMaxHeight = 9; // Maximum height for conversation list
@@ -263,10 +267,10 @@ const App: React.FC<AppProps> = ({ claudeArgs = [], currentDirOnly = false, hide
   const listHeight = Math.min(listMaxHeight, 3 + visibleConversations + needsMoreIndicator);
   
   // Add safety margin to prevent exceeding terminal height
-  const safetyMargin = 1; // Extra margin to account for Static component and any overflow
+  const safetyMargin = SAFETY_MARGIN;
   const bottomMargin = 1;
   const totalUsedHeight = headerHeight + listHeight + bottomMargin + safetyMargin;
-  const previewHeight = Math.max(10, dimensions.height - totalUsedHeight);
+  const previewHeight = Math.max(MIN_PREVIEW_HEIGHT, dimensions.height - totalUsedHeight);
 
   return (
     <Box flexDirection="column" width={dimensions.width} paddingX={1} paddingY={0}>

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -163,12 +163,14 @@ const App: React.FC<AppProps> = ({ claudeArgs = [], currentDirOnly = false, hide
         
         // Small delay to show the message before clearing screen
         setTimeout(() => {
+          // Exit the app first to stop Ink rendering
+          exit();
+          
+          // Output helpful information for the user
           console.log(`\nResuming conversation: ${selectedConv.sessionId}`);
           console.log(`Directory: ${selectedConv.projectPath}`);
-          
-          // Clear the screen and exit the app
-          console.clear();
-          exit();
+          console.log(`Executing: ${commandStr}`);
+          console.log('---');
           
           // Windows-specific reminder before Claude starts
           if (process.platform === 'win32') {
@@ -259,12 +261,15 @@ const App: React.FC<AppProps> = ({ claudeArgs = [], currentDirOnly = false, hide
   // 2 (borders) + 1 (title) + visibleConversations + 1 (more message if needed)
   const needsMoreIndicator = conversations.length > visibleConversations ? 1 : 0;
   const listHeight = Math.min(listMaxHeight, 3 + visibleConversations + needsMoreIndicator);
-  // Add bottom margin (1 line) to prevent overflow
+  
+  // Add safety margin to prevent exceeding terminal height
+  const safetyMargin = 1; // Extra margin to account for Static component and any overflow
   const bottomMargin = 1;
-  const previewHeight = Math.max(10, dimensions.height - headerHeight - listHeight - bottomMargin);
+  const totalUsedHeight = headerHeight + listHeight + bottomMargin + safetyMargin;
+  const previewHeight = Math.max(10, dimensions.height - totalUsedHeight);
 
   return (
-    <Box flexDirection="column" width={dimensions.width} height={dimensions.height} paddingX={1} paddingY={0}>
+    <Box flexDirection="column" width={dimensions.width} paddingX={1} paddingY={0}>
       <Box height={headerHeight} flexDirection="column">
         <Text bold color="cyan">ccresume - Claude Code Conversation Browser</Text>
         <Box>

--- a/src/cli.tsx
+++ b/src/cli.tsx
@@ -94,9 +94,6 @@ if (filteredArgs.includes('--version') || filteredArgs.includes('-v')) {
 
 const claudeArgs = filteredArgs;
 
-// Clear the screen before rendering
-console.clear();
-
 // Show Windows-specific notice at startup with pause
 if (process.platform === 'win32') {
   const { spawn } = await import('child_process');
@@ -115,8 +112,6 @@ if (process.platform === 'win32') {
   await new Promise((resolve) => {
     pause.on('close', resolve);
   });
-  
-  console.clear();
 }
 
 // Render the app in fullscreen mode


### PR DESCRIPTION
## Summary
- Fixed an issue where terminal scrollback buffer was cleared when exiting ccresume
- Implemented proper height management to prevent Ink from clearing the terminal

## Problem
When ccresume's output exceeded the terminal height, Ink would clear the entire terminal including the scrollback buffer. This made it impossible to see previous terminal history after selecting a conversation and launching Claude Code.

## Solution
Added a safety margin to the height calculations to ensure the total rendered output never exceeds the terminal dimensions. This prevents Ink from triggering its `clearTerminal` behavior.

### Key Changes:
1. **Added safety margin**: Introduced `safetyMargin = 1` to account for potential overflow
2. **Removed height constraint**: Removed `height={dimensions.height}` from main Box component
3. **Dynamic height calculation**: Preview height now respects terminal boundaries with safety margin
4. **Code cleanup**: Removed commented-out `console.clear()` calls

## Testing
- Verified scrollback is preserved with `safetyMargin = 1` (minimum working value)
- Confirmed issue reproduces with `safetyMargin = 0`
- Tested on Windows Terminal and VSCode integrated terminal

## Related
- Fixes #3
- Similar approach used by gemini-cli with their `staticExtraHeight` parameter

## Test Plan
1. Run `npm run dev`
2. Select any conversation and press Enter
3. After ccresume exits and Claude Code starts, scroll up in terminal
4. Verify that previous terminal content (before ccresume) is still visible

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved behavior when resuming a conversation to ensure the interface closes before displaying resume details and launching external processes.
  * Adjusted preview pane layout to better handle terminal height and prevent overflow issues.

* **Refactor**
  * Removed unnecessary screen clearing for a smoother user experience, especially on Windows.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->