### PR TITLE
Add git branch display to conversation history

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ dist/
 coverage/
 .nyc_output/
 *.tsbuildinfo
+.claude/settings.local.json

--- a/src/components/ConversationPreview.tsx
+++ b/src/components/ConversationPreview.tsx
@@ -170,10 +170,16 @@ export const ConversationPreview: React.FC<ConversationPreviewProps> = ({ conver
           <Text bold>Session: </Text>
           <Text color="yellow">{conversation.sessionId}</Text>
         </Box>
-        <Box marginBottom={1}>
+        <Box>
           <Text bold>Directory: </Text>
           <Text>{conversation.projectPath}</Text>
         </Box>
+        {conversation.gitBranch && (
+          <Box marginBottom={1}>
+            <Text bold>Branch: </Text>
+            <Text>{conversation.gitBranch}</Text>
+          </Box>
+        )}
       </Box>
 
       {/* Messages area with inner border */}

--- a/src/components/ConversationPreview.tsx
+++ b/src/components/ConversationPreview.tsx
@@ -174,12 +174,10 @@ export const ConversationPreview: React.FC<ConversationPreviewProps> = ({ conver
           <Text bold>Directory: </Text>
           <Text>{conversation.projectPath}</Text>
         </Box>
-        {conversation.gitBranch && (
-          <Box marginBottom={1}>
-            <Text bold>Branch: </Text>
-            <Text>{conversation.gitBranch}</Text>
-          </Box>
-        )}
+        <Box marginBottom={1}>
+          <Text bold>Branch: </Text>
+          <Text>{conversation.gitBranch || '-'}</Text>
+        </Box>
       </Box>
 
       {/* Messages area with inner border */}

--- a/src/types.ts
+++ b/src/types.ts
@@ -21,6 +21,7 @@ export interface Conversation {
   sessionId: string;
   projectPath: string;
   projectName: string;
+  gitBranch?: string | null;
   messages: Message[];
   firstMessage: string;
   lastMessage: string;

--- a/src/utils/conversationReader.ts
+++ b/src/utils/conversationReader.ts
@@ -187,10 +187,27 @@ async function readConversation(filePath: string, projectDir: string): Promise<C
     // Use session ID from filename as it's what Claude expects for --resume
     const sessionId = filenameSessionId;
     
+    const projectPath = messages[0].cwd || '';
+    
+    // Get gitBranch from the last line of the jsonl file
+    let gitBranch: string | null = null;
+    try {
+      const lastLine = lines[lines.length - 1];
+      const lastData = JSON.parse(lastLine);
+      if (lastData.gitBranch !== undefined) {
+        gitBranch = lastData.gitBranch || '-';
+      } else {
+        gitBranch = '-';
+      }
+    } catch {
+      gitBranch = '-';
+    }
+    
     return {
       sessionId,
-      projectPath: messages[0].cwd || '',
+      projectPath,
       projectName,
+      gitBranch,
       messages,
       firstMessage: userMessages.length > 0 ? extractMessageText(userMessages[0].message?.content) : '',
       lastMessage: userMessages.length > 0 ? extractMessageText(userMessages[userMessages.length - 1].message?.content) : '',

--- a/src/utils/conversationReader.ts
+++ b/src/utils/conversationReader.ts
@@ -190,12 +190,14 @@ async function readConversation(filePath: string, projectDir: string): Promise<C
     const projectPath = messages[0].cwd || '';
     
     // Get gitBranch from the last line of the jsonl file
+    // Branch info is stored in the last line by newer versions of Claude Code
     let gitBranch: string | null = null;
     try {
       const lastLine = lines[lines.length - 1];
       const lastData = JSON.parse(lastLine);
       if (lastData.gitBranch !== undefined) {
-        gitBranch = lastData.gitBranch || '-';
+        // Preserve null/empty string values explicitly
+        gitBranch = lastData.gitBranch === null || lastData.gitBranch === '' ? '-' : lastData.gitBranch;
       } else {
         gitBranch = '-';
       }


### PR DESCRIPTION
## Summary
- Added git branch display below Directory in the conversation preview, similar to the official `claude -r` command
- Branch information is read from newer Claude Code log files that include the `gitBranch` field
- Shows `-` for older conversations without branch information

## Changes
- Updated `Conversation` interface to include optional `gitBranch` field
- Modified `conversationReader` to extract branch info from the last line of jsonl files
- Updated `ConversationPreview` component to display branch information
- Added `.claude/settings.local.json` to `.gitignore`

## Test plan
- [x] Build passes without errors
- [x] Lint passes without errors
- [x] Branch displays correctly for conversations with branch info
- [x] Shows `-` for conversations without branch info
- [x] UI layout remains consistent

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Conversations now display a "Branch" field showing the associated git branch if available.

* **Style**
  * Adjusted spacing in the conversation preview to improve layout of metadata fields.

* **Chores**
  * Updated ignore rules to exclude local settings files from version control.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->