### PR TITLE
feat: add experimental full message view mode

### DIFF
--- a/config.toml.example
+++ b/config.toml.example
@@ -33,3 +33,6 @@ startNewSession = ["n"]
 
 # Open command editor to configure Claude CLI options
 openCommandEditor = ["-"]
+
+# Toggle full message view (experimental)
+toggleFullView = ["f"]

--- a/src/components/ConversationPreviewFull.tsx
+++ b/src/components/ConversationPreviewFull.tsx
@@ -1,0 +1,258 @@
+import React, { useState, useEffect } from 'react';
+import { Box, Text, useInput } from 'ink';
+import { format } from 'date-fns';
+import type { Conversation } from '../types.js';
+import { extractMessageText } from '../utils/messageUtils.js';
+
+interface ConversationPreviewFullProps {
+  conversation: Conversation | null;
+  statusMessage?: string | null;
+  hideOptions?: string[];
+}
+
+export const ConversationPreviewFull: React.FC<ConversationPreviewFullProps> = ({ conversation, statusMessage, hideOptions = [] }) => {
+  const [scrollOffset, setScrollOffset] = useState(0);
+
+  // Filter messages based on hideOptions
+  const filteredMessages = conversation ? conversation.messages.filter(msg => {
+    if (!msg || (!msg.message && !msg.toolUseResult)) {
+      return false;
+    }
+    
+    // Get content to check message type
+    let content = '';
+    if (msg.message && msg.message.content) {
+      content = extractMessageText(msg.message.content);
+    } else if (msg.toolUseResult) {
+      // Tool result messages are considered tool messages
+      return !hideOptions.includes('tool');
+    }
+    
+    // Check if this is a tool message
+    if (hideOptions.includes('tool') && content.startsWith('[Tool:')) {
+      return false;
+    }
+    
+    // Check if this is a thinking message
+    if (hideOptions.includes('thinking') && content === '[Thinking...]') {
+      return false;
+    }
+    
+    // Check if we should hide user messages
+    if (hideOptions.includes('user') && msg.type === 'user') {
+      return false;
+    }
+    
+    // Check if we should hide assistant messages
+    if (hideOptions.includes('assistant') && msg.type === 'assistant') {
+      return false;
+    }
+    
+    return true;
+  }) : [];
+
+  useEffect(() => {
+    // When conversation changes, scroll to the bottom (most recent messages)
+    if (conversation) {
+      // Just scroll to the end
+      setScrollOffset(Math.max(0, filteredMessages.length - 1));
+    } else {
+      setScrollOffset(0);
+    }
+  }, [conversation?.sessionId, filteredMessages.length]); // eslint-disable-line react-hooks/exhaustive-deps
+
+  // Disable all keyboard navigation in full view - only mouse scroll works
+  useInput(() => {
+    // Do nothing - keyboard navigation is disabled in full view
+  });
+
+  if (!conversation) {
+    return (
+      <Box flexDirection="column" paddingX={1}>
+        <Text color="gray">No conversation selected</Text>
+      </Box>
+    );
+  }
+
+  // Show all messages from scroll offset onwards, let terminal handle overflow
+  const visibleMessages = filteredMessages.slice(scrollOffset);
+
+  return (
+    <Box flexDirection="column">
+      {visibleMessages.map((msg, index) => {
+          // Skip messages without proper structure
+          if (!msg || (!msg.message && !msg.toolUseResult)) {
+            return null;
+          }
+          
+          const isUser = msg.type === 'user';
+          let content = '';
+          
+          // Handle different message formats
+          if (msg.message && msg.message.content) {
+            // Check if content contains tool_use
+            const messageContent = msg.message.content;
+            if (Array.isArray(messageContent)) {
+              // Collect all content parts
+              const contentParts: string[] = [];
+              
+              // Check for thinking content
+              const thinkingItem = messageContent.find((item: any) => item.type === 'thinking');
+              if (thinkingItem && thinkingItem.thinking) {
+                contentParts.push(`[Thinking...]\n${thinkingItem.thinking.trim()}`);
+              }
+              
+              // Check for regular text content
+              const textItems = messageContent.filter((item: any) => item.type === 'text');
+              textItems.forEach((item: any) => {
+                if (item.text) {
+                  contentParts.push(item.text);
+                }
+              });
+              
+              // Check for tool use
+              const toolUse = messageContent.find((item: any) => item.type === 'tool_use');
+              if (toolUse) {
+                // Format tool use based on tool name
+                if (toolUse.name === 'TodoWrite') {
+                  const input = toolUse.input as any;
+                  if (input?.todos) {
+                    const todos = input.todos;
+                    const todoSummary = todos.map((todo: any) => 
+                      `  ${todo.status === 'completed' ? '✓' : todo.status === 'in_progress' ? '→' : '○'} ${todo.content}`
+                    ).join('\n');
+                    contentParts.push(`[Tool: TodoWrite]\n${todoSummary}`);
+                  } else {
+                    contentParts.push(`[Tool: TodoWrite]`);
+                  }
+                } else if (toolUse.name === 'Edit') {
+                  const input = toolUse.input as any;
+                  const filePath = input?.filePath || input?.file_path || 'file';
+                  const oldStr = input?.oldString || input?.old_string || '';
+                  const newStr = input?.newString || input?.new_string || '';
+                  contentParts.push(`[Tool: Edit] ${filePath}\nOld:\n${oldStr}\nNew:\n${newStr}`);
+                } else if (toolUse.name === 'Read') {
+                  const input = toolUse.input as any;
+                  const filePath = input?.filePath || input?.file_path || 'file';
+                  const lineInfo = input?.offset ? ` (lines ${input.offset}-${input.offset + (input.limit || 50)})` : '';
+                  contentParts.push(`[Tool: Read] ${filePath}${lineInfo}`);
+                } else if (toolUse.name === 'Bash') {
+                  const input = toolUse.input as any;
+                  contentParts.push(`[Tool: Bash] ${input?.command || input?.cmd || ''}`);
+                } else if (toolUse.name === 'Grep') {
+                  const input = toolUse.input as any;
+                  contentParts.push(`[Tool: Grep] pattern: "${input?.pattern || ''}" in ${input?.glob || input?.path || '.'}`);
+                } else if (toolUse.name === 'Glob') {
+                  const input = toolUse.input as any;
+                  contentParts.push(`[Tool: Glob] pattern: "${input?.pattern || ''}"`);
+                } else if (toolUse.name === 'MultiEdit') {
+                  const input = toolUse.input as any;
+                  const filePath = input?.filePath || input?.file_path || 'file';
+                  const edits = input?.edits || [];
+                  const editSummary = edits.map((edit: any, i: number) => 
+                    `Edit ${i + 1}:\nOld:\n${edit.oldString || edit.old_string || ''}\nNew:\n${edit.newString || edit.new_string || ''}`
+                  ).join('\n\n');
+                  contentParts.push(`[Tool: MultiEdit] ${filePath}\n${editSummary}`);
+                } else {
+                  contentParts.push(`[Tool: ${toolUse.name}] ${JSON.stringify(toolUse.input || {}).substring(0, 100)}...`);
+                }
+              }
+              
+              // Join all content parts
+              content = contentParts.join('\n\n');
+              if (!content) {
+                content = extractMessageText(messageContent);
+              }
+            } else {
+              content = extractMessageText(messageContent);
+            }
+          } else if (msg.toolUseResult) {
+            // Handle tool result messages
+            const result = msg.toolUseResult;
+            if (result.oldTodos && result.newTodos) {
+              // TodoWrite result
+              const changes = result.newTodos.filter((newTodo: any) => {
+                const oldTodo = result.oldTodos?.find((old: any) => old.id === newTodo.id);
+                return !oldTodo || oldTodo.status !== newTodo.status || oldTodo.content !== newTodo.content;
+              });
+              content = `[TodoWrite Result] ${changes.length} todos updated`;
+            } else if (result.file || result.filePath) {
+              // Read result
+              const filePath = result.file?.filePath || result.filePath;
+              content = `[Read Result] ${filePath} (${result.file?.numLines || result.numLines || 0} lines)`;
+            } else if (result.oldString && result.newString) {
+              // Edit result
+              content = `[Edit Result] ${result.filePath || 'file'} modified`;
+            } else if (result.stdout) {
+              content = `[Bash Output]\n${result.stdout.trim()}`;
+            } else if (result.stderr) {
+              content = `[Bash Error]\n${result.stderr.trim()}`;
+            } else if (result.filenames && Array.isArray(result.filenames)) {
+              const fileList = result.filenames.slice(0, 5).join('\n  ');
+              const moreCount = result.filenames.length > 5 ? `\n  ... and ${result.filenames.length - 5} more` : '';
+              content = `[Search Results: ${result.filenames.length} files]\n  ${fileList}${moreCount}`;
+            } else {
+              content = `[Tool Result] ${JSON.stringify(result).substring(0, 100)}...`;
+            }
+          }
+          
+          const timestamp = new Date(msg.timestamp);
+          
+          // Skip if timestamp is invalid
+          if (isNaN(timestamp.getTime())) {
+            return null;
+          }
+          
+          
+          const roleText = isUser ? 'User' : 'Assistant';
+          const timeText = format(timestamp, 'HH:mm:ss');
+          
+          // Use a combination of timestamp and index for unique key
+          const uniqueKey = `${msg.timestamp}-${scrollOffset + index}`;
+          
+          return (
+            <Box key={uniqueKey} flexDirection="column">
+              <Text>
+                <Text color={isUser ? 'cyan' : 'green'} bold>[{roleText}]</Text>
+                <Text dimColor> ({timeText})</Text>
+              </Text>
+              {content.split('\n').map((line, lineIndex) => {
+                // Check if this line is a label (starts with [ and contains ])
+                const isLabel = line.startsWith('[') && line.includes(']');
+                
+                if (isLabel) {
+                  const labelMatch = line.match(/^(\[.*?\])(.*)/);
+                  if (labelMatch) {
+                    return (
+                      <Text key={`${uniqueKey}-${lineIndex}`}>
+                        {'  '}
+                        <Text color="yellow">{labelMatch[1]}</Text>
+                        <Text>{labelMatch[2]}</Text>
+                      </Text>
+                    );
+                  }
+                }
+                
+                return (
+                  <Text key={`${uniqueKey}-${lineIndex}`}>
+                    {'  '}
+                    <Text>{line}</Text>
+                  </Text>
+                );
+              })}
+              <Text> </Text>
+            </Box>
+          );
+        }).filter(Boolean)}
+      
+      <Text>━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━</Text>
+      {statusMessage ? (
+        <Text color="green" bold>{statusMessage}</Text>
+      ) : (
+        <Text dimColor>
+          Toggle: f | Quit: q | Currently supports only terminal scroll (use your mouse!)
+        </Text>
+      )}
+    </Box>
+  );
+};

--- a/src/types.ts
+++ b/src/types.ts
@@ -4,7 +4,7 @@ export interface Message {
   type: 'user' | 'assistant';
   message?: {
     role: 'user' | 'assistant';
-    content?: string | Array<{ type: string; text?: string; name?: string; input?: unknown; tool_use_id?: string }>;
+    content?: string | Array<{ type: string; text?: string; name?: string; input?: unknown; tool_use_id?: string; thinking?: string }>;
   };
   cwd: string;
   toolUseResult?: {
@@ -14,6 +14,35 @@ export interface Message {
     durationMs?: number;
     interrupted?: boolean;
     isImage?: boolean;
+    // TodoWrite results
+    oldTodos?: Array<{ id: string; content: string; status: string; priority: string }>;
+    newTodos?: Array<{ id: string; content: string; status: string; priority: string }>;
+    // Read results
+    file?: {
+      filePath: string;
+      content: string;
+      numLines: number;
+      startLine: number;
+      totalLines: number;
+    };
+    filePath?: string;
+    numLines?: number;
+    // Edit results
+    oldString?: string;
+    newString?: string;
+    originalFile?: string;
+    replaceAll?: boolean;
+    structuredPatch?: unknown;
+    userModified?: boolean;
+    // Other tool results
+    type?: string;
+    content?: string;
+    mode?: string;
+    numFiles?: number;
+    totalDurationMs?: number;
+    totalTokens?: number;
+    totalToolUseCount?: number;
+    usage?: unknown;
   };
 }
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -25,7 +25,7 @@ export interface Message {
       startLine: number;
       totalLines: number;
     };
-    filePath?: string;
+    filePath?: string; // Fallback for different result formats
     numLines?: number;
     // Edit results
     oldString?: string;

--- a/src/types/config.ts
+++ b/src/types/config.ts
@@ -14,6 +14,7 @@ export interface KeyBindings {
   pagePrevious: string[];
   startNewSession: string[];
   openCommandEditor: string[];
+  toggleFullView: string[];
 }
 
 export interface Config {
@@ -37,5 +38,6 @@ export const defaultConfig: Config = {
     pagePrevious: ['left'],
     startNewSession: ['n'],
     openCommandEditor: ['-'],
+    toggleFullView: ['f'],
   },
 };

--- a/src/utils/shortcutHelper.ts
+++ b/src/utils/shortcutHelper.ts
@@ -41,6 +41,7 @@ export function getShortcutText(config: Config): string {
   shortcuts.push(`Edit: ${formatKeys(config.keybindings.openCommandEditor)}`);
   shortcuts.push(`Copy ID: ${formatKeys(config.keybindings.copySessionId)}`);
   shortcuts.push(`Quit: ${formatKeys(config.keybindings.quit)}`);
+  shortcuts.push(`Full view: ${formatKeys(config.keybindings.toggleFullView)} (experimental)`);
   
   const shortcutText = shortcuts.join(' • ');
   


### PR DESCRIPTION
## Summary
- Add experimental full message view mode that can be toggled with the 'f' key
- Display complete user and assistant messages without truncation
- Show detailed tool usage information and thinking content

## Features
- **Full Message Display**: Toggle between normal (truncated) and full message view with 'f' key
- **Tool Usage Details**: 
  - TodoWrite: Shows todo items with status indicators (✓/→/○)
  - Edit/MultiEdit: Displays full old/new content
  - Read: Shows file path and line range
  - Bash/Grep/Glob: Shows full commands and parameters
- **Thinking Content**: Extracts and displays Claude's thinking process when available
- **Visual Improvements**:
  - Yellow color for labels like `[Tool:]` and `[Thinking...]`
  - Normal text color for actual content
  - Clean separation between messages
- **Navigation**: In full view mode, only mouse scroll, 'f' (toggle), and 'q' (quit) keys work

## Implementation Details
- New `ConversationPreviewFull` component for rendering full messages
- Extended `Message` type to include thinking content and detailed tool results
- Added `toggleFullView` keybinding to config (default: 'f')
- Marked as experimental feature in the help tooltip

## Test Plan
- [x] Toggle between normal and full view with 'f' key
- [x] Verify tool usage details are displayed correctly
- [x] Confirm thinking content is shown when available
- [x] Test that navigation keys are disabled in full view
- [x] Ensure mouse scroll works in full view
- [x] Check that 'q' key still quits from full view

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Introduced a full conversation preview mode that can be toggled with a new keyboard shortcut (default: "f"). This mode provides a detailed, scrollable view of the conversation with enhanced formatting for messages and tool results.
* **Enhancements**
  * Status messages now indicate when the full view mode is active.
  * Shortcut helper displays the new full view keybinding.
* **Configuration**
  * Added a new configurable keybinding for toggling full conversation view.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->