### PR TITLE
Pre-release improvements and fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- Display git branch in conversation preview for newer Claude Code versions (#46)
+- New session feature - press `n` to start a new Claude session in selected project directory (#48)
+- Interactive command editor - press `-` to edit Claude CLI options before starting/resuming sessions (#49)
+- Full conversation view (experimental) - press `f` to toggle full message view (#50)
+
 ## [0.3.1] - 2025-07-13
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ ccresume provides an interactive terminal interface to browse and manage your Cl
 - 📁 Filter conversations to current directory with `.` argument
 - 🎭 Hide specific message types for cleaner display
 - ⚙️ Edit Claude command options interactively before starting sessions
+- 🔄 Toggle full conversation view to see complete message history
 
 ![ccresume demo](docs/images/demo.gif)
 
@@ -133,6 +134,7 @@ The configured options will be passed to Claude when you start a new session (`n
 | Scroll to Bottom | `G` |
 | Next Page | `→`|
 | Previous Page | `←` |
+| Toggle Full View | `f` |
 
 ### Custom Key Bindings
 
@@ -155,6 +157,7 @@ pageNext = ["right", "n"]
 pagePrevious = ["left", "p"]
 startNewSession = ["n"]
 openCommandEditor = ["-"]
+toggleFullView = ["f"]
 ```
 
 See `config.toml.example` in the repository for a complete example.

--- a/src/__tests__/ConversationPreview.test.tsx
+++ b/src/__tests__/ConversationPreview.test.tsx
@@ -83,9 +83,11 @@ describe('ConversationPreview', () => {
       <ConversationPreview conversation={mockConversation} />
     );
     
-    expect(lastFrame()).toContain('Scroll:');
-    expect(lastFrame()).toContain('Resume:');
-    expect(lastFrame()).toContain('Quit:');
+    // Check for shortcut text - could be either compact or full version
+    const frame = lastFrame();
+    expect(frame).toMatch(/(?:Scroll:|kj:Scroll)/);
+    expect(frame).toMatch(/(?:Resume:|Enter:Resume)/);
+    expect(frame).toMatch(/(?:Quit:|q:Quit)/);
   });
 
   it('shows navigation help for long conversations', () => {
@@ -106,7 +108,7 @@ describe('ConversationPreview', () => {
     
     // Should show navigation help (scroll indicators were removed)
     const frame = lastFrame();
-    const hasShortcuts = frame.includes('Scroll:') && frame.includes('Page:');
+    const hasShortcuts = frame.includes('Scroll:') || frame.includes(':Scroll');
     const hasLoading = frame.includes('Loading shortcuts...');
     expect(hasShortcuts || hasLoading).toBe(true);
   });
@@ -133,7 +135,7 @@ describe('ConversationPreview', () => {
       );
       
       const frame = lastFrame();
-      const hasShortcuts = frame.includes('Scroll:');
+      const hasShortcuts = frame.includes('Scroll:') || frame.includes(':Scroll');
       const hasLoading = frame.includes('Loading shortcuts...');
       expect(hasShortcuts || hasLoading).toBe(true);
     });

--- a/src/__tests__/ConversationPreviewFull.test.tsx
+++ b/src/__tests__/ConversationPreviewFull.test.tsx
@@ -205,6 +205,40 @@ describe('ConversationPreviewFull', () => {
           type: 'assistant',
           message: {
             role: 'assistant',
+            content: [
+              {
+                type: 'thinking',
+                thinking: 'This is my thought process'
+              }
+            ]
+          },
+          cwd: '/test/project'
+        }
+      ]
+    };
+
+    const { lastFrame } = render(
+      <ConversationPreviewFull 
+        conversation={conversationWithThinking} 
+        hideOptions={['thinking']}
+      />
+    );
+    
+    const output = lastFrame();
+    expect(output).not.toContain('[Thinking...]');
+    expect(output).not.toContain('This is my thought process');
+  });
+
+  it('should hide simple thinking string messages when hideOptions includes thinking', () => {
+    const conversationWithThinking: Conversation = {
+      ...mockConversation,
+      messages: [
+        {
+          sessionId: 'test-session-123',
+          timestamp: '2024-01-01T12:00:00Z',
+          type: 'assistant',
+          message: {
+            role: 'assistant',
             content: '[Thinking...]'
           },
           cwd: '/test/project'

--- a/src/__tests__/ConversationPreviewFull.test.tsx
+++ b/src/__tests__/ConversationPreviewFull.test.tsx
@@ -1,0 +1,225 @@
+import React from 'react';
+import { render } from 'ink-testing-library';
+import { ConversationPreviewFull } from '../components/ConversationPreviewFull.js';
+import type { Conversation } from '../types.js';
+
+describe('ConversationPreviewFull', () => {
+  const mockConversation: Conversation = {
+    sessionId: 'test-session-123',
+    projectPath: '/test/project',
+    projectName: 'test-project',
+    gitBranch: 'main',
+    messages: [
+      {
+        sessionId: 'test-session-123',
+        timestamp: '2024-01-01T12:00:00Z',
+        type: 'user',
+        message: {
+          role: 'user',
+          content: 'Hello world'
+        },
+        cwd: '/test/project'
+      },
+      {
+        sessionId: 'test-session-123',
+        timestamp: '2024-01-01T12:00:01Z',
+        type: 'assistant',
+        message: {
+          role: 'assistant',
+          content: 'Hi there!'
+        },
+        cwd: '/test/project'
+      }
+    ],
+    firstMessage: 'Hello world',
+    lastMessage: 'Hi there!',
+    startTime: new Date('2024-01-01T12:00:00Z'),
+    endTime: new Date('2024-01-01T12:00:01Z')
+  };
+
+  it('should render without conversation', () => {
+    const { lastFrame } = render(
+      <ConversationPreviewFull conversation={null} />
+    );
+    
+    expect(lastFrame()).toContain('No conversation selected');
+  });
+
+  it('should render conversation messages', () => {
+    const { lastFrame } = render(
+      <ConversationPreviewFull conversation={mockConversation} />
+    );
+    
+    const output = lastFrame();
+    expect(output).toContain('[User]');
+    expect(output).toContain('Hello world');
+    expect(output).toContain('[Assistant]');
+    expect(output).toContain('Hi there!');
+  });
+
+  it('should show status message when provided', () => {
+    const { lastFrame } = render(
+      <ConversationPreviewFull 
+        conversation={mockConversation} 
+        statusMessage="Test status"
+      />
+    );
+    
+    expect(lastFrame()).toContain('Test status');
+  });
+
+  it('should hide user messages when hideOptions includes user', () => {
+    const { lastFrame } = render(
+      <ConversationPreviewFull 
+        conversation={mockConversation} 
+        hideOptions={['user']}
+      />
+    );
+    
+    const output = lastFrame();
+    expect(output).not.toContain('[User]');
+    expect(output).not.toContain('Hello world');
+    expect(output).toContain('[Assistant]');
+    expect(output).toContain('Hi there!');
+  });
+
+  it('should hide assistant messages when hideOptions includes assistant', () => {
+    const { lastFrame } = render(
+      <ConversationPreviewFull 
+        conversation={mockConversation} 
+        hideOptions={['assistant']}
+      />
+    );
+    
+    const output = lastFrame();
+    expect(output).toContain('[User]');
+    expect(output).toContain('Hello world');
+    expect(output).not.toContain('[Assistant]');
+    expect(output).not.toContain('Hi there!');
+  });
+
+  it('should display tool use messages correctly', () => {
+    const conversationWithTools: Conversation = {
+      ...mockConversation,
+      messages: [
+        {
+          sessionId: 'test-session-123',
+          timestamp: '2024-01-01T12:00:00Z',
+          type: 'assistant',
+          message: {
+            role: 'assistant',
+            content: [
+              {
+                type: 'tool_use',
+                name: 'Read',
+                input: { file_path: '/test/file.ts' }
+              }
+            ]
+          },
+          cwd: '/test/project'
+        }
+      ]
+    };
+
+    const { lastFrame } = render(
+      <ConversationPreviewFull conversation={conversationWithTools} />
+    );
+    
+    const output = lastFrame();
+    expect(output).toContain('[Tool: Read]');
+    expect(output).toContain('/test/file.ts');
+  });
+
+  it('should hide tool messages when hideOptions includes tool', () => {
+    const conversationWithTools: Conversation = {
+      ...mockConversation,
+      messages: [
+        {
+          sessionId: 'test-session-123',
+          timestamp: '2024-01-01T12:00:00Z',
+          type: 'assistant',
+          message: {
+            role: 'assistant',
+            content: [
+              {
+                type: 'tool_use',
+                name: 'Read',
+                input: { file_path: '/test/file.ts' }
+              }
+            ]
+          },
+          cwd: '/test/project'
+        }
+      ]
+    };
+
+    const { lastFrame } = render(
+      <ConversationPreviewFull 
+        conversation={conversationWithTools} 
+        hideOptions={['tool']}
+      />
+    );
+    
+    const output = lastFrame();
+    expect(output).not.toContain('[Tool: Read]');
+  });
+
+  it('should display thinking messages correctly', () => {
+    const conversationWithThinking: Conversation = {
+      ...mockConversation,
+      messages: [
+        {
+          sessionId: 'test-session-123',
+          timestamp: '2024-01-01T12:00:00Z',
+          type: 'assistant',
+          message: {
+            role: 'assistant',
+            content: [
+              {
+                type: 'thinking',
+                thinking: 'This is my thought process'
+              }
+            ]
+          },
+          cwd: '/test/project'
+        }
+      ]
+    };
+
+    const { lastFrame } = render(
+      <ConversationPreviewFull conversation={conversationWithThinking} />
+    );
+    
+    const output = lastFrame();
+    expect(output).toContain('[Thinking...]');
+    expect(output).toContain('This is my thought process');
+  });
+
+  it('should hide thinking messages when hideOptions includes thinking', () => {
+    const conversationWithThinking: Conversation = {
+      ...mockConversation,
+      messages: [
+        {
+          sessionId: 'test-session-123',
+          timestamp: '2024-01-01T12:00:00Z',
+          type: 'assistant',
+          message: {
+            role: 'assistant',
+            content: '[Thinking...]'
+          },
+          cwd: '/test/project'
+        }
+      ]
+    };
+
+    const { lastFrame } = render(
+      <ConversationPreviewFull 
+        conversation={conversationWithThinking} 
+        hideOptions={['thinking']}
+      />
+    );
+    
+    const output = lastFrame();
+    expect(output).not.toContain('[Thinking...]');
+  });
+});

--- a/src/components/ConversationPreview.tsx
+++ b/src/components/ConversationPreview.tsx
@@ -154,7 +154,8 @@ export const ConversationPreview: React.FC<ConversationPreviewProps> = ({ conver
   const visibleMessages = filteredMessages.slice(scrollOffset, scrollOffset + maxVisibleMessages);
   
   // Calculate safe width for text wrapping
-  const safeWidth = Math.max(40, terminalWidth - 20);
+  // Account for borders (2) and padding (2) on each side
+  const safeWidth = Math.max(40, terminalWidth - 4);
 
 
   return (
@@ -168,15 +169,15 @@ export const ConversationPreview: React.FC<ConversationPreviewProps> = ({ conver
         
         <Box>
           <Text bold>Session: </Text>
-          <Text color="yellow">{conversation.sessionId}</Text>
+          <Text color="yellow">{strictTruncateByWidth(conversation.sessionId, safeWidth - 10)}</Text>
         </Box>
         <Box>
           <Text bold>Directory: </Text>
-          <Text>{conversation.projectPath}</Text>
+          <Text>{strictTruncateByWidth(conversation.projectPath, safeWidth - 12)}</Text>
         </Box>
         <Box marginBottom={1}>
           <Text bold>Branch: </Text>
-          <Text>{conversation.gitBranch || '-'}</Text>
+          <Text>{strictTruncateByWidth(conversation.gitBranch || '-', safeWidth - 9)}</Text>
         </Box>
       </Box>
 
@@ -260,7 +261,7 @@ export const ConversationPreview: React.FC<ConversationPreviewProps> = ({ conver
         ) : config ? (
           <Box>
             <Text color="magenta">
-              {getShortcutText(config)}
+              {getShortcutText(config, terminalWidth)}
             </Text>
             {hasKeyConflict(config) && (
               <>

--- a/src/utils/shortcutHelper.ts
+++ b/src/utils/shortcutHelper.ts
@@ -1,6 +1,6 @@
 import { Config } from '../types/config.js';
 
-export function getShortcutText(config: Config): string {
+export function getShortcutText(config: Config, width?: number): string {
   const shortcuts: string[] = [];
   
   // Format keybindings for display
@@ -30,18 +30,32 @@ export function getShortcutText(config: Config): string {
     }).join('/');
   };
   
-  // Build shortcuts in logical groups
-  shortcuts.push(`Select: ${formatKeys(config.keybindings.selectPrevious)}/${formatKeys(config.keybindings.selectNext)}`);
-  shortcuts.push(`Scroll: ${formatKeys(config.keybindings.scrollUp)}/${formatKeys(config.keybindings.scrollDown)}`);
-  shortcuts.push(`Page: ${formatKeys(config.keybindings.scrollPageDown)}/${formatKeys(config.keybindings.scrollPageUp)}`);
-  shortcuts.push(`Top: ${formatKeys(config.keybindings.scrollTop)}`);
-  shortcuts.push(`Bottom: ${formatKeys(config.keybindings.scrollBottom)}`);
-  shortcuts.push(`Resume: ${formatKeys(config.keybindings.confirm)}`);
-  shortcuts.push(`New: ${formatKeys(config.keybindings.startNewSession)}`);
-  shortcuts.push(`Edit: ${formatKeys(config.keybindings.openCommandEditor)}`);
-  shortcuts.push(`Copy ID: ${formatKeys(config.keybindings.copySessionId)}`);
-  shortcuts.push(`Quit: ${formatKeys(config.keybindings.quit)}`);
-  shortcuts.push(`Full view: ${formatKeys(config.keybindings.toggleFullView)} (experimental)`);
+  // Determine which shortcuts to show based on available width
+  const isNarrow = width && width < 120;
+  
+  if (isNarrow) {
+    // Compact version for narrow terminals
+    shortcuts.push(`↑↓:Nav`);
+    shortcuts.push(`${formatKeys(config.keybindings.scrollUp)}${formatKeys(config.keybindings.scrollDown)}:Scroll`);
+    shortcuts.push(`${formatKeys(config.keybindings.confirm)}:Resume`);
+    shortcuts.push(`${formatKeys(config.keybindings.startNewSession)}:New Session`);
+    shortcuts.push(`${formatKeys(config.keybindings.openCommandEditor)}:Edit Options`);
+    shortcuts.push(`${formatKeys(config.keybindings.copySessionId)}:Copy`);
+    shortcuts.push(`${formatKeys(config.keybindings.quit)}:Quit`);
+    shortcuts.push(`${formatKeys(config.keybindings.toggleFullView)}:Full`);
+  } else {
+    // Full version for wider terminals - shortened where possible
+    shortcuts.push(`Nav: ${formatKeys(config.keybindings.selectPrevious)}/${formatKeys(config.keybindings.selectNext)}`);
+    shortcuts.push(`Scroll: ${formatKeys(config.keybindings.scrollUp)}/${formatKeys(config.keybindings.scrollDown)}`);
+    shortcuts.push(`Page: ${formatKeys(config.keybindings.scrollPageUp)}/${formatKeys(config.keybindings.scrollPageDown)}`);
+    shortcuts.push(`Top/Bottom: ${formatKeys(config.keybindings.scrollTop)}/${formatKeys(config.keybindings.scrollBottom)}`);
+    shortcuts.push(`Resume: ${formatKeys(config.keybindings.confirm)}`);
+    shortcuts.push(`New Session: ${formatKeys(config.keybindings.startNewSession)}`);
+    shortcuts.push(`Edit Options: ${formatKeys(config.keybindings.openCommandEditor)}`);
+    shortcuts.push(`Copy: ${formatKeys(config.keybindings.copySessionId)}`);
+    shortcuts.push(`Quit: ${formatKeys(config.keybindings.quit)}`);
+    shortcuts.push(`Full: ${formatKeys(config.keybindings.toggleFullView)} (experimental)`);
+  }
   
   const shortcutText = shortcuts.join(' • ');
   


### PR DESCRIPTION
## Summary
This PR contains pre-release improvements and fixes discovered during final testing:

- 🐛 Fixed TypeScript type warnings in ConversationPreviewFull component
- ✅ Added comprehensive test coverage for ConversationPreviewFull component
- 🎨 Fixed UI issues in narrow terminals (branch/directory overlap)
- 📱 Added responsive shortcut text that adapts to terminal width
- 📝 Improved UI text clarity
- 📚 Updated documentation

## Changes

### Code Quality
- Resolved 15 TypeScript `any` type warnings by adding proper type definitions
- Added type interfaces for all tool inputs (TodoWrite, Edit, Read, etc.)

### Test Coverage
- Created comprehensive test suite for ConversationPreviewFull component
- Added 9 test cases covering rendering, message filtering, and status display
- Updated ConversationPreview tests for new shortcut formats

### UI Improvements
- **Narrow terminal support:**
  - Fixed branch/directory text overlap with proper truncation
  - Corrected width calculations (terminalWidth - 4)
  - Added compact shortcut format for terminals < 120 chars wide
  
- **Improved shortcut text:**
  - Normal view: Shortened labels while keeping clarity
  - "Edit" → "Edit Options" for better understanding
  - "New" → "New Session" for consistency
  - Kept "(experimental)" label for full view feature

### Documentation
- Updated CHANGELOG.md with all new features
- Updated README.md keyboard shortcuts table
- Removed minor details from key features list

## Testing
- ✅ All tests pass (112 tests)
- ✅ TypeScript compilation successful
- ✅ ESLint passes with no warnings
- ✅ Build completes successfully

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added the ability to toggle a full conversation view, displaying the complete message history (default key: `f`).
  * Conversation previews now display the git branch for newer Claude Code versions.
  * Introduced a session feature to start a new Claude session in the selected project directory (triggered by `n`).
  * Added an interactive command editor to modify Claude CLI options before starting or resuming sessions (triggered by `-`).

* **Documentation**
  * Updated the changelog and README to include details about the new full conversation view and related key bindings.

* **Tests**
  * Enhanced and added tests for conversation preview components, including the new full conversation view and shortcut help display.

* **Style**
  * Improved shortcut text formatting to adapt to terminal width for better readability.

* **Refactor**
  * Improved type safety and clarity in handling tool input types and message content within conversation components.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->