### PR TITLE
chore: migrate tooling to mise

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,7 +18,7 @@ jobs:
     - uses: actions/checkout@v6
     
     - name: Setup mise
-      uses: jdx/mise-action@v2
+      uses: jdx/mise-action@v3.5.1
       with:
         tool_versions: node@${{ matrix.node-version }}
         cache: true
@@ -26,17 +26,8 @@ jobs:
     - name: Install dependencies
       run: mise run ci:install
     
-    - name: Run linter
-      run: mise run lint
-    
-    - name: Run type check
-      run: mise run typecheck
-    
-    - name: Run tests
-      run: mise run test
-    
-    - name: Build
-      run: mise run build
+    - name: Run CI checks
+      run: mise run ci
     
     - name: Upload coverage reports
       if: matrix.node-version == '24'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,34 +12,34 @@ jobs:
     
     strategy:
       matrix:
-        node-version: [18.x, 20.x]
+        node-version: [20, 22, 24]
     
     steps:
     - uses: actions/checkout@v6
     
-    - name: Use Node.js ${{ matrix.node-version }}
-      uses: actions/setup-node@v6
+    - name: Setup mise
+      uses: jdx/mise-action@v2
       with:
-        node-version: ${{ matrix.node-version }}
-        cache: 'npm'
+        tools: node@${{ matrix.node-version }}
+        cache: true
     
     - name: Install dependencies
-      run: npm ci
+      run: mise run ci:install
     
     - name: Run linter
-      run: npm run lint
+      run: mise run lint
     
     - name: Run type check
-      run: npm run typecheck
+      run: mise run typecheck
     
     - name: Run tests
-      run: npm test
+      run: mise run test
     
     - name: Build
-      run: npm run build
+      run: mise run build
     
     - name: Upload coverage reports
-      if: matrix.node-version == '20.x'
+      if: matrix.node-version == '24'
       uses: codecov/codecov-action@v5
       with:
         fail_ci_if_error: false

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,7 +20,7 @@ jobs:
     - name: Setup mise
       uses: jdx/mise-action@v2
       with:
-        tools: node@${{ matrix.node-version }}
+        tool_versions: node@${{ matrix.node-version }}
         cache: true
     
     - name: Install dependencies

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,7 +30,7 @@ jobs:
       run: mise run ci
     
     - name: Upload coverage reports
-      if: matrix.node-version == '24'
+      if: matrix.node-version == 24
       uses: codecov/codecov-action@v5
       with:
         fail_ci_if_error: false

--- a/.mise.toml
+++ b/.mise.toml
@@ -1,9 +1,18 @@
 [tools]
 node = "22"
+lefthook = "latest"
 
 [tasks.setup]
 description = "Install dependencies"
 run = "npm install"
+
+[tasks."hooks:install"]
+description = "Install git hooks via lefthook"
+run = "lefthook install"
+
+[tasks.ci]
+description = "Run CI checks locally"
+run = ["mise run lint", "mise run typecheck", "mise run test", "mise run build"]
 
 [tasks."ci:install"]
 description = "Install dependencies for CI"

--- a/.mise.toml
+++ b/.mise.toml
@@ -1,5 +1,5 @@
 [tools]
-node = "22"
+node = "lts"
 lefthook = "latest"
 
 [tasks.setup]
@@ -13,6 +13,26 @@ run = "lefthook install"
 [tasks.ci]
 description = "Run CI checks locally"
 run = ["mise run lint", "mise run typecheck", "mise run test", "mise run build"]
+
+[tasks."ci:node20"]
+description = "Run CI on Node 20"
+run = "mise exec node@20 -- mise run ci"
+
+[tasks."ci:node22"]
+description = "Run CI on Node 22"
+run = "mise exec node@22 -- mise run ci"
+
+[tasks."ci:node24"]
+description = "Run CI on Node 24"
+run = "mise exec node@24 -- mise run ci"
+
+[tasks."ci:matrix"]
+description = "Run CI on supported Node versions (20/22/24)"
+run = ["mise run ci:node20", "mise run ci:node22", "mise run ci:node24"]
+
+[tasks.init]
+description = "Initial setup (deps + hooks)"
+run = ["mise run setup", "mise run hooks:install"]
 
 [tasks."ci:install"]
 description = "Install dependencies for CI"

--- a/.mise.toml
+++ b/.mise.toml
@@ -1,0 +1,38 @@
+[tools]
+node = "22"
+
+[tasks.setup]
+description = "Install dependencies"
+run = "npm install"
+
+[tasks."ci:install"]
+description = "Install dependencies for CI"
+run = "npm ci"
+
+[tasks.dev]
+description = "Run in development mode"
+run = "npm run dev"
+
+[tasks.build]
+description = "Build the project"
+run = "npm run build"
+
+[tasks.lint]
+description = "Run linter"
+run = "npm run lint"
+
+[tasks.typecheck]
+description = "Run type checks"
+run = "npm run typecheck"
+
+[tasks.test]
+description = "Run tests"
+run = "npm test"
+
+[tasks."test:watch"]
+description = "Run tests in watch mode"
+run = "npm run test:watch"
+
+[tasks."test:coverage"]
+description = "Run tests with coverage"
+run = "npm run test:coverage"

--- a/README.md
+++ b/README.md
@@ -178,6 +178,9 @@ mise install
 
 # Install dependencies
 mise run setup
+
+# Install git hooks
+mise run hooks:install
 ```
 
 ### Available Scripts
@@ -203,6 +206,14 @@ mise run lint
 
 # Type check
 mise run typecheck
+```
+
+### Local CI
+
+Run the same checks as CI:
+
+```bash
+mise run ci
 ```
 
 ### Project Structure

--- a/README.md
+++ b/README.md
@@ -97,7 +97,7 @@ ccresume . --hide --dangerously-skip-permissions
 
 ## Requirements
 
-- **Node.js** >= 18
+- **Node.js** >= 20 (LTS)
 - **Claude Code** - Must be installed and configured
 - **Operating System** - Works on macOS, Linux, and Windows (both native & WSL)
 
@@ -166,38 +166,43 @@ See `config.toml.example` in the repository for a complete example.
 
 ### Setup
 
+Install mise if it is not already available in your environment.
+
 ```bash
 # Clone the repository
 git clone https://github.com/yourusername/ccresume.git
 cd ccresume
 
+# Install tools via mise
+mise install
+
 # Install dependencies
-npm install
+mise run setup
 ```
 
 ### Available Scripts
 
 ```bash
 # Run in development mode
-npm run dev
+mise run dev
 
 # Build the project
-npm run build
+mise run build
 
 # Run tests
-npm test
+mise run test
 
 # Run tests in watch mode
-npm run test:watch
+mise run test:watch
 
 # Generate test coverage
-npm run test:coverage
+mise run test:coverage
 
 # Run linter
-npm run lint
+mise run lint
 
 # Type check
-npm run typecheck
+mise run typecheck
 ```
 
 ### Project Structure

--- a/README.md
+++ b/README.md
@@ -97,7 +97,7 @@ ccresume . --hide --dangerously-skip-permissions
 
 ## Requirements
 
-- **Node.js** >= 20 (LTS)
+- **Node.js** 20 / 22 / 24 (LTS)
 - **Claude Code** - Must be installed and configured
 - **Operating System** - Works on macOS, Linux, and Windows (both native & WSL)
 
@@ -168,19 +168,28 @@ See `config.toml.example` in the repository for a complete example.
 
 Install mise if it is not already available in your environment.
 
+#### Install mise
+
+```bash
+curl https://mise.run | sh
+```
+
+See the official getting-started guide for platform-specific steps:
+https://mise.jdx.dev/getting-started.html
+
 ```bash
 # Clone the repository
 git clone https://github.com/yourusername/ccresume.git
 cd ccresume
 
+# Ensure mise is installed before proceeding
+# (skip if already installed)
+
 # Install tools via mise
 mise install
 
-# Install dependencies
-mise run setup
-
-# Install git hooks
-mise run hooks:install
+# Install dependencies and git hooks
+mise run init
 ```
 
 ### Available Scripts
@@ -214,6 +223,14 @@ Run the same checks as CI:
 
 ```bash
 mise run ci
+```
+
+### Compatibility Checks
+
+Validate against all supported Node LTS versions:
+
+```bash
+mise run ci:matrix
 ```
 
 ### Project Structure

--- a/docs/RELEASE.md
+++ b/docs/RELEASE.md
@@ -14,6 +14,7 @@ Before starting the release process, ensure you have:
 - npm authentication configured (`npm login`)
 - git push access to the repository
 - GitHub CLI installed and authenticated (`gh auth login`)
+- mise installed and the toolchain set up (`mise install`)
 
 ## Release Steps
 
@@ -36,16 +37,16 @@ Run all quality checks before creating a release:
 
 ```bash
 # Run linting
-npm run lint
+mise run lint
 
 # Run type checking (if applicable)
-npm run typecheck
+mise run typecheck
 
 # Run tests
-npm test
+mise run test
 
 # Verify package contents
-npm pack --dry-run
+mise exec -- npm pack --dry-run
 ```
 
 ### 3. Merge Release PR
@@ -65,13 +66,13 @@ git pull origin master
 # Then commit any changes
 
 # For bug fixes (1.0.0 → 1.0.1)
-npm version patch -m "Release v%s"
+mise exec -- npm version patch -m "Release v%s"
 
 # For new features (1.0.0 → 1.1.0)
-npm version minor -m "Release v%s"
+mise exec -- npm version minor -m "Release v%s"
 
 # For breaking changes (1.0.0 → 2.0.0)
-npm version major -m "Release v%s"
+mise exec -- npm version major -m "Release v%s"
 ```
 
 ### 5. Push Changes
@@ -87,7 +88,7 @@ git push origin master --follow-tags
 Publish the package to npm registry:
 
 ```bash
-npm publish
+mise exec -- npm publish
 ```
 
 ### 7. Create GitHub Release
@@ -96,7 +97,7 @@ Create a GitHub release using the CHANGELOG content:
 
 ```bash
 # Extract the latest version section from CHANGELOG.md
-VERSION=$(node -p "require('./package.json').version")
+VERSION=$(mise exec -- node -p "require('./package.json').version")
 NOTES=$(awk "/^## \[$VERSION\]/{flag=1;next}/^## \[/{flag=0}flag" CHANGELOG.md)
 
 # Create release with CHANGELOG notes
@@ -144,26 +145,26 @@ git checkout master
 git pull origin master
 
 echo "Running pre-release checks..."
-npm run lint
-npm run typecheck
-npm test
+mise run lint
+mise run typecheck
+mise run test
 
 echo "Creating release..."
-npm version "$1" -m "Release v%s"
+mise exec -- npm version "$1" -m "Release v%s"
 
 echo "Pushing to repository..."
 git push origin master --follow-tags
 
 echo "Publishing to npm..."
-npm publish
+mise exec -- npm publish
 
 echo "Creating GitHub release..."
-VERSION=$(node -p "require('./package.json').version")
+VERSION=$(mise exec -- node -p "require('./package.json').version")
 NOTES=$(awk "/^## \[$VERSION\]/{flag=1;next}/^## \[/{flag=0}flag" CHANGELOG.md)
 gh release create "v$VERSION" --notes "$NOTES"
 
 echo "Creating merge-back PR..."
-gh pr create --base develop --head master --title "chore: merge back v$(node -p "require('./package.json').version") release changes" --body "Merge back release changes"
+gh pr create --base develop --head master --title "chore: merge back v$(mise exec -- node -p "require('./package.json').version") release changes" --body "Merge back release changes"
 
 echo "Release complete!"
 ```

--- a/lefthook.yml
+++ b/lefthook.yml
@@ -1,0 +1,11 @@
+pre-commit:
+  commands:
+    lint:
+      run: mise run lint
+    typecheck:
+      run: mise run typecheck
+
+pre-push:
+  commands:
+    ci:
+      run: mise run ci

--- a/package.json
+++ b/package.json
@@ -59,7 +59,7 @@
     "typescript-eslint": "^8.35.1"
   },
   "engines": {
-    "node": ">=18"
+    "node": ">=20"
   },
   "files": [
     "dist"


### PR DESCRIPTION
## Summary
- add mise tasks for setup/build/test/lint/typecheck
- move CI Node setup and commands to mise with 20/22/24 LTS matrix
- update docs and engine requirements to Node >=20

## Testing
- mise run test
- mise run lint
- mise run typecheck

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Raised minimum Node.js requirement to >=20 and updated CI to run on Node 20, 22, and 24.
  * Switched primary tooling to the mise CLI for install, build, lint, typecheck, and test flows; CI consolidated into a single mise-run step.
* **New Features**
  * Added a reusable local task configuration with convenient CI task variants.
  * Added git hooks to run lint/typecheck and CI checks.
* **Documentation**
  * Updated setup, development, local CI, and release instructions to use mise-based commands.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->