### PR TITLE
fix: skip non-directory entries when scanning projects dir

### DIFF
--- a/src/__tests__/conversationReader.test.ts
+++ b/src/__tests__/conversationReader.test.ts
@@ -1,0 +1,133 @@
+import { jest } from '@jest/globals';
+import { beforeEach, describe, expect, it } from '@jest/globals';
+import type { Dirent } from 'fs';
+
+// FAKE_HOME must be defined before mockHomedir so the module-level homedir() call resolves.
+const FAKE_HOME = '/home/testuser';
+const PROJECTS_DIR = `${FAKE_HOME}/.claude/projects`;
+
+const mockReaddir = jest.fn();
+const mockReadFile = jest.fn();
+const mockStat = jest.fn();
+// Set initial return value here so conversationReader.ts's module-level `join(homedir(), ...)` works.
+const mockHomedir = jest.fn().mockReturnValue(FAKE_HOME);
+
+jest.unstable_mockModule('fs/promises', () => ({
+  readdir: mockReaddir,
+  readFile: mockReadFile,
+  stat: mockStat,
+}));
+
+jest.unstable_mockModule('os', () => ({
+  homedir: mockHomedir,
+}));
+
+const { getAllConversations, getPaginatedConversations } = await import('../utils/conversationReader.js');
+
+function makeDirent(name: string, isDir: boolean): Dirent {
+  return {
+    name,
+    parentPath: PROJECTS_DIR,
+    path: PROJECTS_DIR,
+    isDirectory: () => isDir,
+    isFile: () => !isDir,
+    isBlockDevice: () => false,
+    isCharacterDevice: () => false,
+    isFIFO: () => false,
+    isSocket: () => false,
+    isSymbolicLink: () => false,
+  } as unknown as Dirent;
+}
+
+describe('conversationReader', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    // Restore after clearAllMocks since homedir is consumed at module-level.
+    mockHomedir.mockReturnValue(FAKE_HOME);
+  });
+
+  describe('getAllConversations', () => {
+    it('ignores non-directory entries in projects dir to avoid ENOTDIR', async () => {
+      // Simulates claude-code-log placing cache.db and index.html alongside project dirs.
+      // Before the fix, readdir(projectPath) on these files would throw ENOTDIR.
+      mockReaddir.mockImplementation((path: unknown, opts?: unknown) => {
+        if (path === PROJECTS_DIR && (opts as { withFileTypes?: boolean } | undefined)?.withFileTypes) {
+          return Promise.resolve([
+            makeDirent('claude-code-log-cache.db', false),
+            makeDirent('index.html', false),
+            makeDirent('-Users-testuser-my-project', true),
+          ]);
+        }
+        return Promise.resolve([]);
+      });
+
+      const result = await getAllConversations();
+      expect(result).toEqual([]);
+    });
+
+    it('returns empty array when projects dir does not exist', async () => {
+      mockReaddir.mockRejectedValue(
+        Object.assign(new Error('ENOENT: no such file or directory'), { code: 'ENOENT' })
+      );
+
+      const result = await getAllConversations();
+      expect(result).toEqual([]);
+    });
+
+    it('processes directory entries normally when no non-directory entries exist', async () => {
+      mockReaddir.mockImplementation((path: unknown, opts?: unknown) => {
+        if (path === PROJECTS_DIR && (opts as { withFileTypes?: boolean } | undefined)?.withFileTypes) {
+          return Promise.resolve([
+            makeDirent('-Users-testuser-my-project', true),
+          ]);
+        }
+        // project dir contains no jsonl files
+        return Promise.resolve([]);
+      });
+
+      const result = await getAllConversations();
+      expect(Array.isArray(result)).toBe(true);
+      expect(result).toEqual([]);
+    });
+
+    it('returns empty array when projects dir is empty', async () => {
+      mockReaddir.mockImplementation((_path: unknown, opts?: unknown) => {
+        if ((opts as { withFileTypes?: boolean } | undefined)?.withFileTypes) {
+          return Promise.resolve([]);
+        }
+        return Promise.resolve([]);
+      });
+
+      const result = await getAllConversations();
+      expect(result).toEqual([]);
+    });
+  });
+
+  describe('getPaginatedConversations', () => {
+    it('ignores non-directory entries in projects dir to avoid ENOTDIR', async () => {
+      mockReaddir.mockImplementation((path: unknown, opts?: unknown) => {
+        if (path === PROJECTS_DIR && (opts as { withFileTypes?: boolean } | undefined)?.withFileTypes) {
+          return Promise.resolve([
+            makeDirent('claude-code-log-cache.db', false),
+            makeDirent('index.html', false),
+            makeDirent('-Users-testuser-my-project', true),
+          ]);
+        }
+        return Promise.resolve([]);
+      });
+
+      const result = await getPaginatedConversations({ limit: 10, offset: 0 });
+      expect(result.conversations).toEqual([]);
+    });
+
+    it('returns empty conversations and total=0 when projects dir does not exist', async () => {
+      mockReaddir.mockRejectedValue(
+        Object.assign(new Error('ENOENT: no such file or directory'), { code: 'ENOENT' })
+      );
+
+      const result = await getPaginatedConversations({ limit: 10, offset: 0 });
+      expect(result.conversations).toEqual([]);
+      expect(result.total).toBe(0);
+    });
+  });
+});

--- a/src/utils/conversationReader.ts
+++ b/src/utils/conversationReader.ts
@@ -29,8 +29,11 @@ export async function getPaginatedConversations(options: PaginationOptions): Pro
   const allFiles: Array<{path: string, dir: string, mtime: Date}> = [];
   
   try {
-    const projectDirs = await readdir(CLAUDE_PROJECTS_DIR);
-    
+    // Skip non-directory entries (e.g. claude-code-log's cache .db / index.html) to avoid ENOTDIR.
+    const projectDirs = (await readdir(CLAUDE_PROJECTS_DIR, { withFileTypes: true }))
+      .filter((entry) => entry.isDirectory())
+      .map((entry) => entry.name);
+
     // If filtering by directory, convert the filter path to Claude's directory name format
     const targetDir = options.currentDirFilter ? pathToClaudeDir(options.currentDirFilter) : null;
     
@@ -100,8 +103,11 @@ export async function getAllConversations(currentDirFilter?: string): Promise<Co
   const conversations: Conversation[] = [];
   
   try {
-    const projectDirs = await readdir(CLAUDE_PROJECTS_DIR);
-    
+    // Skip non-directory entries (e.g. claude-code-log's cache .db / index.html) to avoid ENOTDIR.
+    const projectDirs = (await readdir(CLAUDE_PROJECTS_DIR, { withFileTypes: true }))
+      .filter((entry) => entry.isDirectory())
+      .map((entry) => entry.name);
+
     for (const projectDir of projectDirs) {
       const projectPath = join(CLAUDE_PROJECTS_DIR, projectDir);
       const files = await readdir(projectPath);


### PR DESCRIPTION
## Summary

Fixes a crash (`ENOTDIR`) that occurs when non-directory files exist directly under `~/.claude/projects/`.

## Symptom

```
Error: ENOTDIR: not a directory, scandir '/Users/.../.claude/projects/claude-code-log-cache.db'
Error: ENOTDIR: not a directory, scandir '/Users/.../.claude/projects/index.html'
```

## How to reproduce

```bash
touch ~/.claude/projects/foo.txt
ccresume
# → crashes with ENOTDIR
```

## Root cause

`getPaginatedConversations` and `getAllConversations` in `src/utils/conversationReader.ts` call `readdir(CLAUDE_PROJECTS_DIR)` and then immediately call `readdir(entry)` on every returned entry, assuming all of them are directories. Any non-directory file in that folder causes `ENOTDIR`.

A concrete trigger: [claude-code-log](https://github.com/anthropics/claude-code-log) v1.2.0 places two files directly under `~/.claude/projects/`:

- `claude-code-log-cache.db` — SQLite cache (296 MB in my case)
- `index.html` — generated by `--all-projects` mode

Both are hardcoded paths in claude-code-log and cannot be relocated via its CLI options.

## Fix

Pass `{ withFileTypes: true }` to `readdir(CLAUDE_PROJECTS_DIR)` and filter the results to directories only before iterating:

```ts
// Before
const projectDirs = await readdir(CLAUDE_PROJECTS_DIR);

// After
const projectDirs = (await readdir(CLAUDE_PROJECTS_DIR, { withFileTypes: true }))
  .filter((entry) => entry.isDirectory())
  .map((entry) => entry.name);
```

Applied to both functions. The inner `readdir(projectPath)` call already filters for `.jsonl` files so it is unaffected.

## Tests

Added `src/__tests__/conversationReader.test.ts` with 6 cases:

| Function | Scenario |
|---|---|
| `getAllConversations` | Mixed entries (`.db` + `.html` + dir) → no ENOTDIR, returns `[]` |
| `getAllConversations` | Directory entries only → works as before |
| `getAllConversations` | Empty projects dir → returns `[]` |
| `getAllConversations` | Projects dir doesn't exist (ENOENT) → returns `[]` |
| `getPaginatedConversations` | Mixed entries → no ENOTDIR, returns empty conversations |
| `getPaginatedConversations` | Projects dir doesn't exist (ENOENT) → returns `{ conversations: [], total: 0 }` |

All 119 tests pass (`mise run ci`).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an issue where cache files stored alongside project directories could cause errors when retrieving conversations and pagination data.

* **Tests**
  * Added comprehensive test coverage for conversation retrieval to ensure proper handling of mixed directory and file entries, missing directories, and edge cases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->