### PR TITLE
fix: skip non-directory entries when scanning projects dir

### DIFF
--- a/src/__tests__/conversationReader.test.ts
+++ b/src/__tests__/conversationReader.test.ts
@@ -123,7 +123,7 @@ describe('conversationReader', () => {
     });
 
     it('returns empty array when projects dir is empty', async () => {
-      mockReaddir.mockImplementation((_path: unknown) => {
+      mockReaddir.mockImplementation(() => {
         return Promise.resolve([]);
       });
 

--- a/src/__tests__/conversationReader.test.ts
+++ b/src/__tests__/conversationReader.test.ts
@@ -52,6 +52,7 @@ describe('conversationReader', () => {
     it('ignores non-directory entries in projects dir to avoid ENOTDIR', async () => {
       // Simulates claude-code-log placing cache.db and index.html alongside project dirs.
       // readdir(projectPath) on those files throws ENOTDIR, which must be silently skipped.
+      // Also verifies that the valid sibling directory is still scanned and returns conversations.
       mockReaddir.mockImplementation((path: unknown) => {
         if (path === PROJECTS_DIR) {
           return Promise.resolve(['claude-code-log-cache.db', 'index.html', '-Users-testuser-my-project']);
@@ -62,11 +63,16 @@ describe('conversationReader', () => {
         if (path === `${PROJECTS_DIR}/index.html`) {
           return Promise.reject(makeEnotdir());
         }
+        if (path === `${PROJECTS_DIR}/-Users-testuser-my-project`) {
+          return Promise.resolve([VALID_JSONL_FILE]);
+        }
         return Promise.resolve([]);
       });
+      mockReadFile.mockResolvedValue(VALID_JSONL_PAYLOAD);
 
       const result = await getAllConversations();
-      expect(result).toEqual([]);
+      expect(result).toHaveLength(1);
+      expect(result[0].sessionId).toBe(VALID_UUID);
     });
 
     it('scans symlinked project directories and returns conversations from them', async () => {
@@ -116,20 +122,6 @@ describe('conversationReader', () => {
       expect(result).toEqual([]);
     });
 
-    it('processes directory entries normally when no non-directory entries exist', async () => {
-      mockReaddir.mockImplementation((path: unknown) => {
-        if (path === PROJECTS_DIR) {
-          return Promise.resolve(['-Users-testuser-my-project']);
-        }
-        // project dir contains no jsonl files
-        return Promise.resolve([]);
-      });
-
-      const result = await getAllConversations();
-      expect(Array.isArray(result)).toBe(true);
-      expect(result).toEqual([]);
-    });
-
     it('returns empty array when projects dir is empty', async () => {
       mockReaddir.mockImplementation((_path: unknown) => {
         return Promise.resolve([]);
@@ -142,6 +134,7 @@ describe('conversationReader', () => {
 
   describe('getPaginatedConversations', () => {
     it('ignores non-directory entries in projects dir to avoid ENOTDIR', async () => {
+      // Also verifies that the valid sibling directory is still scanned and returns conversations.
       mockReaddir.mockImplementation((path: unknown) => {
         if (path === PROJECTS_DIR) {
           return Promise.resolve(['claude-code-log-cache.db', 'index.html', '-Users-testuser-my-project']);
@@ -152,11 +145,17 @@ describe('conversationReader', () => {
         if (path === `${PROJECTS_DIR}/index.html`) {
           return Promise.reject(makeEnotdir());
         }
+        if (path === `${PROJECTS_DIR}/-Users-testuser-my-project`) {
+          return Promise.resolve([VALID_JSONL_FILE]);
+        }
         return Promise.resolve([]);
       });
+      mockReadFile.mockResolvedValue(VALID_JSONL_PAYLOAD);
+      mockStat.mockResolvedValue({ mtime: new Date('2026-05-07T10:00:00.000Z') });
 
       const result = await getPaginatedConversations({ limit: 10, offset: 0 });
-      expect(result.conversations).toEqual([]);
+      expect(result.conversations).toHaveLength(1);
+      expect(result.conversations[0].sessionId).toBe(VALID_UUID);
     });
 
     it('scans symlinked project directories and returns conversations from them', async () => {

--- a/src/__tests__/conversationReader.test.ts
+++ b/src/__tests__/conversationReader.test.ts
@@ -1,0 +1,133 @@
+import { jest } from '@jest/globals';
+import { beforeEach, describe, expect, it } from '@jest/globals';
+import type { Dirent } from 'fs';
+
+// FAKE_HOME must be defined before mockHomedir so the module-level homedir() call resolves.
+const FAKE_HOME = '/home/testuser';
+const PROJECTS_DIR = `${FAKE_HOME}/.claude/projects`;
+
+const mockReaddir = jest.fn();
+const mockReadFile = jest.fn();
+const mockStat = jest.fn();
+// Set initial return value here so conversationReader.ts's module-level `join(homedir(), ...)` works.
+const mockHomedir = jest.fn().mockReturnValue(FAKE_HOME);
+
+jest.unstable_mockModule('fs/promises', () => ({
+  readdir: mockReaddir,
+  readFile: mockReadFile,
+  stat: mockStat,
+}));
+
+jest.unstable_mockModule('os', () => ({
+  homedir: mockHomedir,
+}));
+
+const { getAllConversations, getPaginatedConversations } = await import('../utils/conversationReader.js');
+
+function makeDirent(name: string, isDir: boolean): Dirent {
+  return {
+    name,
+    parentPath: PROJECTS_DIR,
+    path: PROJECTS_DIR,
+    isDirectory: () => isDir,
+    isFile: () => !isDir,
+    isBlockDevice: () => false,
+    isCharacterDevice: () => false,
+    isFIFO: () => false,
+    isSocket: () => false,
+    isSymbolicLink: () => false,
+  } as unknown as Dirent;
+}
+
+describe('conversationReader', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    // Restore after clearAllMocks since homedir is consumed at module-level.
+    mockHomedir.mockReturnValue(FAKE_HOME);
+  });
+
+  describe('getAllConversations', () => {
+    it('ignores non-directory entries in projects dir to avoid ENOTDIR', async () => {
+      // Simulates claude-code-log placing cache.db and index.html alongside project dirs.
+      // Before the fix, readdir(projectPath) on these files would throw ENOTDIR.
+      mockReaddir.mockImplementation((path: unknown, opts?: unknown) => {
+        if (path === PROJECTS_DIR && (opts as { withFileTypes?: boolean } | undefined)?.withFileTypes) {
+          return Promise.resolve([
+            makeDirent('claude-code-log-cache.db', false),
+            makeDirent('index.html', false),
+            makeDirent('-Users-testuser-my-project', true),
+          ]);
+        }
+        return Promise.resolve([]);
+      });
+
+      const result = await getAllConversations();
+      expect(result).toEqual([]);
+    });
+
+    it('returns empty array when projects dir does not exist', async () => {
+      mockReaddir.mockRejectedValue(
+        Object.assign(new Error('ENOENT: no such file or directory'), { code: 'ENOENT' })
+      );
+
+      const result = await getAllConversations();
+      expect(result).toEqual([]);
+    });
+
+    it('processes directory entries normally when no non-directory entries exist', async () => {
+      mockReaddir.mockImplementation((path: unknown, opts?: unknown) => {
+        if (path === PROJECTS_DIR && (opts as { withFileTypes?: boolean } | undefined)?.withFileTypes) {
+          return Promise.resolve([
+            makeDirent('-Users-testuser-my-project', true),
+          ]);
+        }
+        // project dir contains no jsonl files
+        return Promise.resolve([]);
+      });
+
+      const result = await getAllConversations();
+      expect(Array.isArray(result)).toBe(true);
+      expect(result).toEqual([]);
+    });
+
+    it('returns empty array when projects dir is empty', async () => {
+      mockReaddir.mockImplementation((_path: unknown, opts?: unknown) => {
+        if ((opts as { withFileTypes?: boolean } | undefined)?.withFileTypes) {
+          return Promise.resolve([]);
+        }
+        return Promise.resolve([]);
+      });
+
+      const result = await getAllConversations();
+      expect(result).toEqual([]);
+    });
+  });
+
+  describe('getPaginatedConversations', () => {
+    it('ignores non-directory entries in projects dir to avoid ENOTDIR', async () => {
+      mockReaddir.mockImplementation((path: unknown, opts?: unknown) => {
+        if (path === PROJECTS_DIR && (opts as { withFileTypes?: boolean } | undefined)?.withFileTypes) {
+          return Promise.resolve([
+            makeDirent('claude-code-log-cache.db', false),
+            makeDirent('index.html', false),
+            makeDirent('-Users-testuser-my-project', true),
+          ]);
+        }
+        return Promise.resolve([]);
+      });
+
+      const result = await getPaginatedConversations({ limit: 10, offset: 0 });
+      expect(result.conversations).toEqual([]);
+    });
+
+    it('returns empty conversations and total=0 when projects dir does not exist', async () => {
+      mockReaddir.mockRejectedValue(
+        Object.assign(new Error('ENOENT: no such file or directory'), { code: 'ENOENT' })
+      );
+
+      const result = await getPaginatedConversations({ limit: 10, offset: 0 });
+      expect(result.conversations).toEqual([]);
+      expect(result.total).toBe(0);
+    });
+  });
+});

--- a/src/__tests__/conversationReader.test.ts
+++ b/src/__tests__/conversationReader.test.ts
@@ -1,6 +1,5 @@
 import { jest } from '@jest/globals';
 import { beforeEach, describe, expect, it } from '@jest/globals';
-import type { Dirent } from 'fs';
 
 // FAKE_HOME must be defined before mockHomedir so the module-level homedir() call resolves.
 const FAKE_HOME = '/home/testuser';
@@ -24,19 +23,8 @@ jest.unstable_mockModule('os', () => ({
 
 const { getAllConversations, getPaginatedConversations } = await import('../utils/conversationReader.js');
 
-function makeDirent(name: string, isDir: boolean): Dirent {
-  return {
-    name,
-    parentPath: PROJECTS_DIR,
-    path: PROJECTS_DIR,
-    isDirectory: () => isDir,
-    isFile: () => !isDir,
-    isBlockDevice: () => false,
-    isCharacterDevice: () => false,
-    isFIFO: () => false,
-    isSocket: () => false,
-    isSymbolicLink: () => false,
-  } as unknown as Dirent;
+function makeEnotdir(): Error {
+  return Object.assign(new Error('ENOTDIR: not a directory'), { code: 'ENOTDIR' });
 }
 
 describe('conversationReader', () => {
@@ -49,20 +37,40 @@ describe('conversationReader', () => {
   describe('getAllConversations', () => {
     it('ignores non-directory entries in projects dir to avoid ENOTDIR', async () => {
       // Simulates claude-code-log placing cache.db and index.html alongside project dirs.
-      // Before the fix, readdir(projectPath) on these files would throw ENOTDIR.
-      mockReaddir.mockImplementation((path: unknown, opts?: unknown) => {
-        if (path === PROJECTS_DIR && (opts as { withFileTypes?: boolean } | undefined)?.withFileTypes) {
-          return Promise.resolve([
-            makeDirent('claude-code-log-cache.db', false),
-            makeDirent('index.html', false),
-            makeDirent('-Users-testuser-my-project', true),
-          ]);
+      // readdir(projectPath) on those files throws ENOTDIR, which must be silently skipped.
+      mockReaddir.mockImplementation((path: unknown) => {
+        if (path === PROJECTS_DIR) {
+          return Promise.resolve(['claude-code-log-cache.db', 'index.html', '-Users-testuser-my-project']);
+        }
+        if (path === `${PROJECTS_DIR}/claude-code-log-cache.db`) {
+          return Promise.reject(makeEnotdir());
+        }
+        if (path === `${PROJECTS_DIR}/index.html`) {
+          return Promise.reject(makeEnotdir());
         }
         return Promise.resolve([]);
       });
 
       const result = await getAllConversations();
       expect(result).toEqual([]);
+    });
+
+    it('scans symlinked project directories (symlink-to-dir must not be skipped)', async () => {
+      // Verifies the regression fix: Dirent.isDirectory() returns false for symlinks, but
+      // readdir() follows the link, so ENOTDIR is not thrown and the dir is scanned normally.
+      mockReaddir.mockImplementation((path: unknown) => {
+        if (path === PROJECTS_DIR) {
+          return Promise.resolve(['symlinked-project']);
+        }
+        if (path === `${PROJECTS_DIR}/symlinked-project`) {
+          // readdir follows the symlink and returns the actual directory contents
+          return Promise.resolve([]);
+        }
+        return Promise.resolve([]);
+      });
+
+      const result = await getAllConversations();
+      expect(Array.isArray(result)).toBe(true);
     });
 
     it('returns empty array when projects dir does not exist', async () => {
@@ -75,11 +83,9 @@ describe('conversationReader', () => {
     });
 
     it('processes directory entries normally when no non-directory entries exist', async () => {
-      mockReaddir.mockImplementation((path: unknown, opts?: unknown) => {
-        if (path === PROJECTS_DIR && (opts as { withFileTypes?: boolean } | undefined)?.withFileTypes) {
-          return Promise.resolve([
-            makeDirent('-Users-testuser-my-project', true),
-          ]);
+      mockReaddir.mockImplementation((path: unknown) => {
+        if (path === PROJECTS_DIR) {
+          return Promise.resolve(['-Users-testuser-my-project']);
         }
         // project dir contains no jsonl files
         return Promise.resolve([]);
@@ -91,10 +97,7 @@ describe('conversationReader', () => {
     });
 
     it('returns empty array when projects dir is empty', async () => {
-      mockReaddir.mockImplementation((_path: unknown, opts?: unknown) => {
-        if ((opts as { withFileTypes?: boolean } | undefined)?.withFileTypes) {
-          return Promise.resolve([]);
-        }
+      mockReaddir.mockImplementation((_path: unknown) => {
         return Promise.resolve([]);
       });
 
@@ -105,13 +108,30 @@ describe('conversationReader', () => {
 
   describe('getPaginatedConversations', () => {
     it('ignores non-directory entries in projects dir to avoid ENOTDIR', async () => {
-      mockReaddir.mockImplementation((path: unknown, opts?: unknown) => {
-        if (path === PROJECTS_DIR && (opts as { withFileTypes?: boolean } | undefined)?.withFileTypes) {
-          return Promise.resolve([
-            makeDirent('claude-code-log-cache.db', false),
-            makeDirent('index.html', false),
-            makeDirent('-Users-testuser-my-project', true),
-          ]);
+      mockReaddir.mockImplementation((path: unknown) => {
+        if (path === PROJECTS_DIR) {
+          return Promise.resolve(['claude-code-log-cache.db', 'index.html', '-Users-testuser-my-project']);
+        }
+        if (path === `${PROJECTS_DIR}/claude-code-log-cache.db`) {
+          return Promise.reject(makeEnotdir());
+        }
+        if (path === `${PROJECTS_DIR}/index.html`) {
+          return Promise.reject(makeEnotdir());
+        }
+        return Promise.resolve([]);
+      });
+
+      const result = await getPaginatedConversations({ limit: 10, offset: 0 });
+      expect(result.conversations).toEqual([]);
+    });
+
+    it('scans symlinked project directories (symlink-to-dir must not be skipped)', async () => {
+      mockReaddir.mockImplementation((path: unknown) => {
+        if (path === PROJECTS_DIR) {
+          return Promise.resolve(['symlinked-project']);
+        }
+        if (path === `${PROJECTS_DIR}/symlinked-project`) {
+          return Promise.resolve([]);
         }
         return Promise.resolve([]);
       });

--- a/src/__tests__/conversationReader.test.ts
+++ b/src/__tests__/conversationReader.test.ts
@@ -27,6 +27,20 @@ function makeEnotdir(): Error {
   return Object.assign(new Error('ENOTDIR: not a directory'), { code: 'ENOTDIR' });
 }
 
+function makeEnoent(): Error {
+  return Object.assign(new Error('ENOENT: no such file or directory'), { code: 'ENOENT' });
+}
+
+const VALID_UUID = '12345678-1234-1234-1234-123456789abc';
+const VALID_JSONL_FILE = `${VALID_UUID}.jsonl`;
+const VALID_JSONL_PAYLOAD = JSON.stringify({
+  type: 'user',
+  message: { content: 'hello world' },
+  timestamp: '2026-05-07T10:00:00.000Z',
+  cwd: '/Users/testuser/my-project',
+  gitBranch: 'main',
+});
+
 describe('conversationReader', () => {
   beforeEach(() => {
     jest.clearAllMocks();
@@ -55,22 +69,42 @@ describe('conversationReader', () => {
       expect(result).toEqual([]);
     });
 
-    it('scans symlinked project directories (symlink-to-dir must not be skipped)', async () => {
-      // Verifies the regression fix: Dirent.isDirectory() returns false for symlinks, but
-      // readdir() follows the link, so ENOTDIR is not thrown and the dir is scanned normally.
+    it('scans symlinked project directories and returns conversations from them', async () => {
       mockReaddir.mockImplementation((path: unknown) => {
         if (path === PROJECTS_DIR) {
           return Promise.resolve(['symlinked-project']);
         }
         if (path === `${PROJECTS_DIR}/symlinked-project`) {
-          // readdir follows the symlink and returns the actual directory contents
-          return Promise.resolve([]);
+          return Promise.resolve([VALID_JSONL_FILE]);
         }
         return Promise.resolve([]);
       });
+      mockReadFile.mockResolvedValue(VALID_JSONL_PAYLOAD);
 
       const result = await getAllConversations();
-      expect(Array.isArray(result)).toBe(true);
+      expect(result).toHaveLength(1);
+      expect(result[0].sessionId).toBe(VALID_UUID);
+      expect(result[0].firstMessage).toBe('hello world');
+    });
+
+    it('skips broken symlinks (ENOENT on inner readdir) without discarding sibling conversations', async () => {
+      mockReaddir.mockImplementation((path: unknown) => {
+        if (path === PROJECTS_DIR) {
+          return Promise.resolve(['broken-symlink', '-Users-testuser-my-project']);
+        }
+        if (path === `${PROJECTS_DIR}/broken-symlink`) {
+          return Promise.reject(makeEnoent());
+        }
+        if (path === `${PROJECTS_DIR}/-Users-testuser-my-project`) {
+          return Promise.resolve([VALID_JSONL_FILE]);
+        }
+        return Promise.resolve([]);
+      });
+      mockReadFile.mockResolvedValue(VALID_JSONL_PAYLOAD);
+
+      const result = await getAllConversations();
+      expect(result).toHaveLength(1);
+      expect(result[0].sessionId).toBe(VALID_UUID);
     });
 
     it('returns empty array when projects dir does not exist', async () => {
@@ -125,19 +159,44 @@ describe('conversationReader', () => {
       expect(result.conversations).toEqual([]);
     });
 
-    it('scans symlinked project directories (symlink-to-dir must not be skipped)', async () => {
+    it('scans symlinked project directories and returns conversations from them', async () => {
       mockReaddir.mockImplementation((path: unknown) => {
         if (path === PROJECTS_DIR) {
           return Promise.resolve(['symlinked-project']);
         }
         if (path === `${PROJECTS_DIR}/symlinked-project`) {
-          return Promise.resolve([]);
+          return Promise.resolve([VALID_JSONL_FILE]);
         }
         return Promise.resolve([]);
       });
+      mockReadFile.mockResolvedValue(VALID_JSONL_PAYLOAD);
+      mockStat.mockResolvedValue({ mtime: new Date('2026-05-07T10:00:00.000Z') });
 
       const result = await getPaginatedConversations({ limit: 10, offset: 0 });
-      expect(result.conversations).toEqual([]);
+      expect(result.conversations).toHaveLength(1);
+      expect(result.conversations[0].sessionId).toBe(VALID_UUID);
+      expect(result.conversations[0].firstMessage).toBe('hello world');
+    });
+
+    it('skips broken symlinks (ENOENT on inner readdir) without discarding sibling conversations', async () => {
+      mockReaddir.mockImplementation((path: unknown) => {
+        if (path === PROJECTS_DIR) {
+          return Promise.resolve(['broken-symlink', '-Users-testuser-my-project']);
+        }
+        if (path === `${PROJECTS_DIR}/broken-symlink`) {
+          return Promise.reject(makeEnoent());
+        }
+        if (path === `${PROJECTS_DIR}/-Users-testuser-my-project`) {
+          return Promise.resolve([VALID_JSONL_FILE]);
+        }
+        return Promise.resolve([]);
+      });
+      mockReadFile.mockResolvedValue(VALID_JSONL_PAYLOAD);
+      mockStat.mockResolvedValue({ mtime: new Date('2026-05-07T10:00:00.000Z') });
+
+      const result = await getPaginatedConversations({ limit: 10, offset: 0 });
+      expect(result.conversations).toHaveLength(1);
+      expect(result.conversations[0].sessionId).toBe(VALID_UUID);
     });
 
     it('returns empty conversations and total=0 when projects dir does not exist', async () => {

--- a/src/utils/conversationReader.ts
+++ b/src/utils/conversationReader.ts
@@ -29,8 +29,11 @@ export async function getPaginatedConversations(options: PaginationOptions): Pro
   const allFiles: Array<{path: string, dir: string, mtime: Date}> = [];
   
   try {
-    const projectDirs = await readdir(CLAUDE_PROJECTS_DIR);
-    
+    // Skip non-directory entries (e.g. claude-code-log's cache .db / index.html) to avoid ENOTDIR.
+    const projectDirs = (await readdir(CLAUDE_PROJECTS_DIR, { withFileTypes: true }))
+      .filter((entry) => entry.isDirectory())
+      .map((entry) => entry.name);
+
     // If filtering by directory, convert the filter path to Claude's directory name format
     const targetDir = options.currentDirFilter ? pathToClaudeDir(options.currentDirFilter) : null;
     
@@ -100,8 +103,11 @@ export async function getAllConversations(currentDirFilter?: string): Promise<Co
   const conversations: Conversation[] = [];
   
   try {
-    const projectDirs = await readdir(CLAUDE_PROJECTS_DIR);
-    
+    // Skip non-directory entries (e.g. claude-code-log's cache .db / index.html) to avoid ENOTDIR.
+    const projectDirs = (await readdir(CLAUDE_PROJECTS_DIR, { withFileTypes: true }))
+      .filter((entry) => entry.isDirectory())
+      .map((entry) => entry.name);
+
     for (const projectDir of projectDirs) {
       const projectPath = join(CLAUDE_PROJECTS_DIR, projectDir);
       const files = await readdir(projectPath);

--- a/src/utils/conversationReader.ts
+++ b/src/utils/conversationReader.ts
@@ -41,18 +41,20 @@ export async function getPaginatedConversations(options: PaginationOptions): Pro
       }
 
       const projectPath = join(CLAUDE_PROJECTS_DIR, projectDir);
-      // ENOTDIR means this entry is a plain file or a symlink-to-file (e.g. claude-code-log's cache
-      // .db/.html). Skip it silently; symlink-to-dir works fine because readdir follows the link.
+      // ENOTDIR: entry is a plain file or symlink-to-file (e.g. claude-code-log's .db/.html).
+      // ENOENT: entry is a broken symlink (target missing). Skip both silently;
+      // symlink-to-dir works fine because readdir follows the link.
       let dirFiles: string[];
       try {
         dirFiles = await readdir(projectPath);
       } catch (err) {
-        if ((err as NodeJS.ErrnoException).code === 'ENOTDIR') {
+        const code = (err as NodeJS.ErrnoException).code;
+        if (code === 'ENOTDIR' || code === 'ENOENT') {
           continue;
         }
         throw err;
       }
-      const jsonlFiles = dirFiles.filter(f => f.endsWith('.jsonl') && 
+      const jsonlFiles = dirFiles.filter(f => f.endsWith('.jsonl') &&
         /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}\.jsonl$/i.test(f));
       
       for (const file of jsonlFiles) {
@@ -114,13 +116,15 @@ export async function getAllConversations(currentDirFilter?: string): Promise<Co
 
     for (const projectDir of projectDirs) {
       const projectPath = join(CLAUDE_PROJECTS_DIR, projectDir);
-      // ENOTDIR means this entry is a plain file or a symlink-to-file (e.g. claude-code-log's cache
-      // .db/.html). Skip it silently; symlink-to-dir works fine because readdir follows the link.
+      // ENOTDIR: entry is a plain file or symlink-to-file (e.g. claude-code-log's .db/.html).
+      // ENOENT: entry is a broken symlink (target missing). Skip both silently;
+      // symlink-to-dir works fine because readdir follows the link.
       let files: string[];
       try {
         files = await readdir(projectPath);
       } catch (err) {
-        if ((err as NodeJS.ErrnoException).code === 'ENOTDIR') {
+        const code = (err as NodeJS.ErrnoException).code;
+        if (code === 'ENOTDIR' || code === 'ENOENT') {
           continue;
         }
         throw err;

--- a/src/utils/conversationReader.ts
+++ b/src/utils/conversationReader.ts
@@ -29,22 +29,29 @@ export async function getPaginatedConversations(options: PaginationOptions): Pro
   const allFiles: Array<{path: string, dir: string, mtime: Date}> = [];
   
   try {
-    // Skip non-directory entries (e.g. claude-code-log's cache .db / index.html) to avoid ENOTDIR.
-    const projectDirs = (await readdir(CLAUDE_PROJECTS_DIR, { withFileTypes: true }))
-      .filter((entry) => entry.isDirectory())
-      .map((entry) => entry.name);
+    const projectDirs = await readdir(CLAUDE_PROJECTS_DIR);
 
     // If filtering by directory, convert the filter path to Claude's directory name format
     const targetDir = options.currentDirFilter ? pathToClaudeDir(options.currentDirFilter) : null;
-    
+
     for (const projectDir of projectDirs) {
       // Skip directories that don't match the filter early
       if (targetDir && projectDir !== targetDir) {
         continue;
       }
-      
+
       const projectPath = join(CLAUDE_PROJECTS_DIR, projectDir);
-      const dirFiles = await readdir(projectPath);
+      // ENOTDIR means this entry is a plain file or a symlink-to-file (e.g. claude-code-log's cache
+      // .db/.html). Skip it silently; symlink-to-dir works fine because readdir follows the link.
+      let dirFiles: string[];
+      try {
+        dirFiles = await readdir(projectPath);
+      } catch (err) {
+        if ((err as NodeJS.ErrnoException).code === 'ENOTDIR') {
+          continue;
+        }
+        throw err;
+      }
       const jsonlFiles = dirFiles.filter(f => f.endsWith('.jsonl') && 
         /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}\.jsonl$/i.test(f));
       
@@ -103,14 +110,21 @@ export async function getAllConversations(currentDirFilter?: string): Promise<Co
   const conversations: Conversation[] = [];
   
   try {
-    // Skip non-directory entries (e.g. claude-code-log's cache .db / index.html) to avoid ENOTDIR.
-    const projectDirs = (await readdir(CLAUDE_PROJECTS_DIR, { withFileTypes: true }))
-      .filter((entry) => entry.isDirectory())
-      .map((entry) => entry.name);
+    const projectDirs = await readdir(CLAUDE_PROJECTS_DIR);
 
     for (const projectDir of projectDirs) {
       const projectPath = join(CLAUDE_PROJECTS_DIR, projectDir);
-      const files = await readdir(projectPath);
+      // ENOTDIR means this entry is a plain file or a symlink-to-file (e.g. claude-code-log's cache
+      // .db/.html). Skip it silently; symlink-to-dir works fine because readdir follows the link.
+      let files: string[];
+      try {
+        files = await readdir(projectPath);
+      } catch (err) {
+        if ((err as NodeJS.ErrnoException).code === 'ENOTDIR') {
+          continue;
+        }
+        throw err;
+      }
       const jsonlFiles = files.filter(f => f.endsWith('.jsonl'));
       
       for (const file of jsonlFiles) {


### PR DESCRIPTION
## Summary

Fixes a crash (`ENOTDIR`) that occurs when non-directory files exist directly under `~/.claude/projects/`.

## Symptom

```
Error: ENOTDIR: not a directory, scandir '/Users/.../.claude/projects/claude-code-log-cache.db'
Error: ENOTDIR: not a directory, scandir '/Users/.../.claude/projects/index.html'
```

## How to reproduce

```bash
touch ~/.claude/projects/foo.txt
ccresume
# → crashes with ENOTDIR
```

## Root cause

`getPaginatedConversations` and `getAllConversations` in `src/utils/conversationReader.ts` call `readdir(CLAUDE_PROJECTS_DIR)` and then immediately call `readdir(entry)` on every returned entry, assuming all of them are directories. Any non-directory file in that folder causes `ENOTDIR`.

A concrete trigger: [claude-code-log](https://github.com/anthropics/claude-code-log) v1.2.0 places two files directly under `~/.claude/projects/`:

- `claude-code-log-cache.db` — SQLite cache (296 MB in my case)
- `index.html` — generated by `--all-projects` mode

Both are hardcoded paths in claude-code-log and cannot be relocated via its CLI options.

## Fix

Pass `{ withFileTypes: true }` to `readdir(CLAUDE_PROJECTS_DIR)` and filter the results to directories only before iterating:

```ts
// Before
const projectDirs = await readdir(CLAUDE_PROJECTS_DIR);

// After
const projectDirs = (await readdir(CLAUDE_PROJECTS_DIR, { withFileTypes: true }))
  .filter((entry) => entry.isDirectory())
  .map((entry) => entry.name);
```

Applied to both functions. The inner `readdir(projectPath)` call already filters for `.jsonl` files so it is unaffected.

## Tests

Added `src/__tests__/conversationReader.test.ts` with 6 cases:

| Function | Scenario |
|---|---|
| `getAllConversations` | Mixed entries (`.db` + `.html` + dir) → no ENOTDIR, returns `[]` |
| `getAllConversations` | Directory entries only → works as before |
| `getAllConversations` | Empty projects dir → returns `[]` |
| `getAllConversations` | Projects dir doesn't exist (ENOENT) → returns `[]` |
| `getPaginatedConversations` | Mixed entries → no ENOTDIR, returns empty conversations |
| `getPaginatedConversations` | Projects dir doesn't exist (ENOENT) → returns `{ conversations: [], total: 0 }` |

All 119 tests pass (`mise run ci`).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Conversation loading and pagination now robustly skip non-directory entries and broken/missing project links, avoiding crashes and correctly returning empty results when projects are missing or empty.
  * Pagination ordering now reliably uses modification times for consistent paging.

* **Tests**
  * Added comprehensive tests covering normal, missing, broken, and empty project directory scenarios and pagination.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->